### PR TITLE
발표 준비/진행 페이지 api 연결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "react-router-dom": "^6.8.1",
         "recharts": "^3.2.1",
         "sockjs-client": "^1.6.1",
-        "styled-components": "^6.1.19"
+        "styled-components": "^6.1.19",
+        "uuid": "^13.0.0"
       },
       "devDependencies": {
         "@types/react": "^18.2.43",
@@ -5619,6 +5620,19 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/victory-vendor": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react-router-dom": "^6.8.1",
     "recharts": "^3.2.1",
     "sockjs-client": "^1.6.1",
-    "styled-components": "^6.1.19"
+    "styled-components": "^6.1.19",
+    "uuid": "^13.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.43",

--- a/src/components/HeaderBar/index.jsx
+++ b/src/components/HeaderBar/index.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import styled, { css } from "styled-components";
-import { useLocation, useNavigate, useMatch } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import BoiniLogo from "../../assets/images/Boini_logo.svg";
 import LiveIcon from "../../assets/images/live.png";
 import ShareModal from "../modal/ShareModal";
@@ -11,7 +11,6 @@ import {
   StartSessionButton,
 } from "../common/HeaderButtons";
 
-/* ===== 헤더 전체 래퍼 ===== */
 const HeaderWrapper = styled.header`
   width: 100vw;
   height: 5.2vh;
@@ -27,7 +26,6 @@ const HeaderWrapper = styled.header`
   box-sizing: border-box;
 `;
 
-/* ===== 로고 ===== */
 const Logo = styled.div`
   display: flex;
   align-items: center;
@@ -49,7 +47,6 @@ const Logo = styled.div`
         `}
 `;
 
-/* ===== 중앙 영역 ===== */
 const Body = styled.div`
   flex: 1;
   display: flex;
@@ -57,7 +54,6 @@ const Body = styled.div`
   justify-content: center;
 `;
 
-/* ===== 파일명 표시 ===== */
 const FileName = styled.div`
   font-size: clamp(12px, 0.95vw, 18px);
   color: #5c5c5c;
@@ -68,7 +64,6 @@ const FileName = styled.div`
   max-width: 50vw;
 `;
 
-/* ===== 라이브 뱃지 ===== */
 const LiveBadge = styled.div`
   display: inline-flex;
   align-items: center;
@@ -88,7 +83,6 @@ const LiveBadge = styled.div`
   }
 `;
 
-/* ===== 우측 버튼 영역 ===== */
 const RightActions = styled.div`
   display: inline-flex;
   align-items: center;
@@ -99,13 +93,13 @@ const RightActions = styled.div`
 function HeaderBar() {
   const location = useLocation();
   const navigate = useNavigate();
+
   const isMain = location.pathname === "/";
   const isRating = location.pathname === "/rating";
   const isAiReport = location.pathname === "/ai-report";
   const isAudienceView = location.pathname === "/audience";
   const isPrep = location.pathname === "/create-presentation";
-  const isCodeRoute = Boolean(useMatch(":code"));
-  const isAudienceLike = isAudienceView || isCodeRoute;
+  const isPresenter = location.pathname === "/presentation";
 
   const fileName = location.state?.fileName;
   const { slides, sessionId, features, maxParticipants } = location.state || {};
@@ -113,16 +107,25 @@ function HeaderBar() {
   const [showShareModal, setShowShareModal] = useState(false);
   const { roomData, loading, initRoom } = useRoom();
 
-  const handleStartSession = () => {
-    navigate("/presentation", {
-      state: { slides, sessionId, features, maxParticipants },
-    });
+  const handleSessionAction = () => {
+    if (isPrep) {
+      navigate("/presentation", {
+        state: {
+          slides,
+          sessionId,
+          features,
+          maxParticipants,
+          fileName,
+        },
+      });
+    } else if (isPresenter) {
+      navigate("/");
+    }
   };
 
-  // === 공유하기 버튼 클릭 시 ===
   const handleShareClick = async () => {
     if (!roomData) {
-      await initRoom(slides?.length || 10); // PDF 페이지 수 넘겨줌
+      await initRoom(slides?.length || 10);
     }
     setShowShareModal(true);
   };
@@ -130,40 +133,41 @@ function HeaderBar() {
   return (
     <>
       <HeaderWrapper>
-        {/* ===== 로고 ===== */}
         <Logo $isMain={isMain || isRating || isAiReport}>
           <img src={BoiniLogo} alt="Boini logo" />
         </Logo>
 
-        {/* ===== 중앙 내용 ===== */}
         {!isMain && (
           <Body>
-            {isAudienceLike && (
+            {isAudienceView && (
               <LiveBadge>
                 <img src={LiveIcon} alt="live" />
                 라이브 진행 중
               </LiveBadge>
             )}
-            {isPrep && <FileName>{fileName || "파일명 없음"}</FileName>}
+            {(isPrep || isPresenter) && (
+              <FileName>{fileName || "파일명 없음"}</FileName>
+            )}
           </Body>
         )}
 
-        {/* ===== 우측 버튼 ===== */}
-        {(isAudienceLike || isPrep || isAiReport) && (
+        {(isAudienceView || isPrep || isPresenter || isAiReport) && (
           <RightActions>
-            {(isAudienceLike || isPrep) && (
+            {(isAudienceView || isPrep || isPresenter) && (
               <ShareButton onClick={handleShareClick} disabled={loading} />
             )}
-            {isPrep ? (
-              <StartSessionButton onClick={handleStartSession} />
-            ) : (
-              <ExitButton />
+
+            {(isPrep || isPresenter) && (
+              <StartSessionButton onClick={handleSessionAction}>
+                {isPrep ? "세션 시작" : "세션 종료"}
+              </StartSessionButton>
             )}
+
+            {isAudienceView && <ExitButton />}
           </RightActions>
         )}
       </HeaderWrapper>
 
-      {/* ===== 공유 모달 ===== */}
       {showShareModal && roomData && (
         <ShareModal
           sessionLink={roomData.joinUrl}

--- a/src/components/HeaderBar/index.jsx
+++ b/src/components/HeaderBar/index.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import styled, { css } from "styled-components";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate, useMatch } from "react-router-dom";
 import BoiniLogo from "../../assets/images/Boini_logo.svg";
 import LiveIcon from "../../assets/images/live.png";
 import ShareModal from "../modal/ShareModal";
@@ -11,6 +11,7 @@ import {
   StartSessionButton,
 } from "../common/HeaderButtons";
 
+/* ===== 헤더 전체 래퍼 ===== */
 const HeaderWrapper = styled.header`
   width: 100vw;
   height: 5.2vh;
@@ -26,6 +27,7 @@ const HeaderWrapper = styled.header`
   box-sizing: border-box;
 `;
 
+/* ===== 로고 ===== */
 const Logo = styled.div`
   display: flex;
   align-items: center;
@@ -47,6 +49,7 @@ const Logo = styled.div`
         `}
 `;
 
+/* ===== 중앙 영역 ===== */
 const Body = styled.div`
   flex: 1;
   display: flex;
@@ -54,6 +57,7 @@ const Body = styled.div`
   justify-content: center;
 `;
 
+/* ===== 파일명 표시 ===== */
 const FileName = styled.div`
   font-size: clamp(12px, 0.95vw, 18px);
   color: #5c5c5c;
@@ -64,6 +68,7 @@ const FileName = styled.div`
   max-width: 50vw;
 `;
 
+/* ===== 라이브 뱃지 ===== */
 const LiveBadge = styled.div`
   display: inline-flex;
   align-items: center;
@@ -83,6 +88,7 @@ const LiveBadge = styled.div`
   }
 `;
 
+/* ===== 우측 버튼 영역 ===== */
 const RightActions = styled.div`
   display: inline-flex;
   align-items: center;
@@ -100,6 +106,8 @@ function HeaderBar() {
   const isAudienceView = location.pathname === "/audience";
   const isPrep = location.pathname === "/create-presentation";
   const isPresenter = location.pathname === "/presentation";
+  const isCodeRoute = Boolean(useMatch(":code"));
+  const isAudienceLike = isAudienceView || isCodeRoute;
 
   const fileName = location.state?.fileName;
   const { slides, sessionId, features, maxParticipants } = location.state || {};

--- a/src/components/Layout/Layout.jsx
+++ b/src/components/Layout/Layout.jsx
@@ -1,0 +1,22 @@
+// src/components/Layout/Layout.jsx
+import React from "react";
+import HeaderBar from "../HeaderBar";
+import { LayoutContainer } from "./Layout.styles";
+
+const Layout = ({ children, headerProps = {} }) => {
+    return (
+        <LayoutContainer style={{ flexDirection: "column" }}>
+            <HeaderBar
+                roomId={headerProps.roomId}
+                deckId={headerProps.deckId}
+                totalPages={headerProps.totalPages}
+            />
+
+            <div style={{ flex: 1, display: "flex", overflow: "hidden" }}>
+                {children}
+            </div>
+        </LayoutContainer>
+    );
+};
+
+export default Layout;

--- a/src/components/SidebarSlides/index.jsx
+++ b/src/components/SidebarSlides/index.jsx
@@ -36,7 +36,7 @@ const SidebarSlides = ({
             {isWaiting ? (
               <SlidePlaceholder />
             ) : (
-              <SlideImage src={slide} alt={`슬라이드 ${i + 1}`} />
+              <SlideImage src={slide.thumbnailUrl || slide} alt={`슬라이드 ${i + 1}`} />
             )}
             {/* <SlideIndex>{i + 1}</SlideIndex> */}
             <SlideIndex $active={!isWaiting && i === currentSlide}>

--- a/src/components/SlideViewer/SlideContainer.jsx
+++ b/src/components/SlideViewer/SlideContainer.jsx
@@ -13,8 +13,11 @@ const SlideContainer = ({ src, alt = "슬라이드 이미지" }) => {
                 src={src}
                 alt={alt}
                 style={{
-                    maxWidth: "100%",
-                    height: "auto",
+                    // maxWidth: "100%",
+                    // height: "auto",
+                    width: "100%",
+                    height: "100%",
+                    objectFit: "contain",
                     borderRadius: "0.6vw",
                     border: "0.05vw solid #eee",
                 }}

--- a/src/components/SlideViewer/index.jsx
+++ b/src/components/SlideViewer/index.jsx
@@ -86,8 +86,9 @@ const SlideViewer = ({
 
       {/* 🔹 슬라이드 */}
       <SlideContainer
-        src={slides[currentSlide]}
+        src={slides[currentSlide]?.thumbnailUrl || slides[currentSlide]}
         alt={`슬라이드 ${currentSlide + 1}`}
+        style={{ objectFit: "contain" }}
       />
     </Main>
   );

--- a/src/components/modal/ShareModal.jsx
+++ b/src/components/modal/ShareModal.jsx
@@ -122,13 +122,22 @@ const CloseBtn = styled.button`
 `;
 
 /* ============ 컴포넌트 ============ */
-const ShareModal = ({ totalPages = 10, onClose }) => {
+const ShareModal = ({ roomData, totalPages = 10, onClose }) => {
     const [sessionLink, setSessionLink] = useState("");
     const [qrBase64, setQrBase64] = useState("");
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState("");
 
     useEffect(() => {
+        // roomData가 이미 전달된 경우 (CreateSessionPage에서 생성된 방 사용)
+        if (roomData) {
+            setSessionLink(roomData.joinUrl);
+            setQrBase64(roomData.qrPngBase64);
+            setLoading(false);
+            return;
+        }
+
+        // roomData가 없을 때만 새로 방 생성 (다른 곳에서 사용할 수도 있음)
         const initRoom = async () => {
             try {
                 const data = await createRoom(totalPages);
@@ -142,7 +151,7 @@ const ShareModal = ({ totalPages = 10, onClose }) => {
             }
         };
         initRoom();
-    }, [totalPages]);
+    }, [roomData, totalPages]);
 
     const handleCopy = () => {
         if (!sessionLink) return;

--- a/src/hooks/usePdfConverter.js
+++ b/src/hooks/usePdfConverter.js
@@ -13,20 +13,28 @@ export default function usePdfConverter() {
     const convertPdfToImages = async (file) => {
         try {
             setLoading(true);
+            setError(null);
+
             const arrayBuffer = await file.arrayBuffer();
             const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
             const imgs = [];
 
+            // ✅ 화질 개선: scale 2.5 (기존 1.5보다 고해상도)
             for (let i = 1; i <= pdf.numPages; i++) {
                 const page = await pdf.getPage(i);
-                const viewport = page.getViewport({ scale: 1.5 });
+                const viewport = page.getViewport({ scale: 2.5 });
                 const canvas = document.createElement("canvas");
                 const ctx = canvas.getContext("2d");
+
                 canvas.width = viewport.width;
                 canvas.height = viewport.height;
+
                 await page.render({ canvasContext: ctx, viewport }).promise;
                 imgs.push(canvas.toDataURL("image/png"));
             }
+
+            // ✅ 비동기 안정화 (state 업데이트 타이밍 보장)
+            await new Promise((resolve) => setTimeout(resolve, 0));
             setSlides(imgs);
         } catch (err) {
             setError(err.message);
@@ -35,5 +43,5 @@ export default function usePdfConverter() {
         }
     };
 
-    return { slides, loading, error, convertPdfToImages };
+    return { slides, setSlides, loading, error, convertPdfToImages };
 }

--- a/src/pages/CreateSession/CreateSessionPage.jsx
+++ b/src/pages/CreateSession/CreateSessionPage.jsx
@@ -1,12 +1,18 @@
 import React, { useState, useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
+import { v4 as uuidv4 } from "uuid";
 import usePdfConverter from "../../hooks/usePdfConverter";
-import usePresentationSession from "../../hooks/usePresentationSession";
-import Layout from "../../components/Layout/LayoutContainer";
+import { createRoom } from "../../services/roomService";
+import api from "../../services/api";
+
+// 🔹 HeaderBar 포함 Layout 사용 (새로운 Layout.jsx)
+import Layout from "../../components/Layout/Layout";
+
 import SidebarSlides from "../../components/SidebarSlides";
 import SlideViewer from "../../components/SlideViewer";
 import SettingsPanel from "../../components/SettingsPanel";
 import LandingPage from "../../components/LandingPage";
+import ShareModal from "../../components/modal/ShareModal";
 
 const PresentationPrepPage = () => {
   const location = useLocation();
@@ -14,39 +20,130 @@ const PresentationPrepPage = () => {
   const { pdfFile } = location.state || {};
 
   const [currentSlide, setCurrentSlide] = useState(0);
-  const { slides, convertPdfToImages } = usePdfConverter();
-  const {
-    participantCount,
-    maxParticipants,
-    setMaxParticipants,
-    sessionId,
-    features,
-    toggleFeature,
-  } = usePresentationSession();
+  const [roomId, setRoomId] = useState(null);
+  const [roomData, setRoomData] = useState(null);
+  const [deckId] = useState(uuidv4());
+  const [isShareModalOpen, setIsShareModalOpen] = useState(false);
+  const [imagesLoaded, setImagesLoaded] = useState(false);
+
+  const { slides, setSlides, convertPdfToImages } = usePdfConverter();
 
   useEffect(() => {
-    if (pdfFile) convertPdfToImages(pdfFile);
-    else navigate("/");
+    if (pdfFile) {
+      convertPdfToImages(pdfFile);
+    } else {
+      navigate("/");
+    }
   }, [pdfFile]);
 
-  const handleStart = () =>
-    navigate("/presentation", { state: { slides, sessionId, features, maxParticipants } });
+  useEffect(() => {
+    if (!slides || slides.length === 0) return;
 
-  if (!slides.length) return <LandingPage message="세션 자료 정리 중..." />;
+    const initRoom = async () => {
+      try {
+        const room = await createRoom(slides.length);
+        setRoomId(room.roomId);
+        setRoomData(room);
+        console.log("🏠 방 생성 완료:", room.roomId);
+      } catch {
+        alert("방 생성 중 오류가 발생했습니다.");
+      }
+    };
+
+    initRoom();
+  }, [slides.length, deckId]);
+
+  useEffect(() => {
+    const uploadSlides = async () => {
+      if (!roomId || !slides || slides.length === 0) return;
+
+      const formData = new FormData();
+      slides.forEach((dataUrl, idx) => {
+        const blob = dataURLtoBlob(dataUrl);
+        formData.append("files", blob, `page_${idx + 1}.png`);
+      });
+
+      try {
+        const res = await api.post(`/api/presentations/${roomId}/${deckId}/pages`, formData);
+        console.log(" 업로드 성공:", res.data);
+
+        const totalPages = res.data?.data?.totalPages || slides.length;
+        const slideUrls = Array.from({ length: totalPages }, (_, i) => ({
+          page: i + 1,
+          thumbnailUrl: `/api/presentations/${roomId}/${deckId}/pages/${i + 1}?ext=png`,
+        }));
+
+        setSlides(slideUrls);
+        console.log("서버 경로 기반 slides 생성 완료:", slideUrls);
+      } catch (err) {
+        console.error("❌ 슬라이드 업로드 실패:", err);
+      }
+    };
+
+    uploadSlides();
+  }, [roomId, slides, deckId]);
+
+
+  useEffect(() => {
+    if (!slides || slides.length === 0) return;
+
+    const loadPromises = slides.map((slide) => {
+      return new Promise((resolve) => {
+        const img = new Image();
+        img.src = slide.thumbnailUrl || slide;
+        img.onload = () => resolve(true);
+        img.onerror = () => resolve(false);
+      });
+    });
+
+    Promise.all(loadPromises).then(() => {
+      setImagesLoaded(true);
+      console.log("🖼️ 모든 슬라이드 이미지 로드 완료");
+    });
+  }, [slides]);
+
+  if (!slides || slides.length === 0 || !imagesLoaded)
+    return <LandingPage message="세션 자료 준비 중..." />;
 
   return (
-    <Layout>
+    <Layout
+      headerProps={{
+        roomId,
+        deckId,
+        totalPages: slides.length,
+      }}
+    >
       <SidebarSlides
         slides={slides}
         currentSlide={currentSlide}
         setCurrentSlide={setCurrentSlide}
-        participantCount={participantCount}
-        maxParticipants={maxParticipants}
       />
-      <SlideViewer slides={slides} currentSlide={currentSlide} setCurrentSlide={setCurrentSlide} mode="prepare"/>
+      <SlideViewer
+        slides={slides}
+        currentSlide={currentSlide}
+        setCurrentSlide={setCurrentSlide}
+        mode="prepare"
+      />
       <SettingsPanel />
+
+      {isShareModalOpen && (
+        <ShareModal
+          roomData={roomData}
+          onClose={() => setIsShareModalOpen(false)}
+        />
+      )}
     </Layout>
   );
 };
 
 export default PresentationPrepPage;
+
+function dataURLtoBlob(dataUrl) {
+  const arr = dataUrl.split(",");
+  const mime = arr[0].match(/:(.*?);/)[1];
+  const bstr = atob(arr[1]);
+  let n = bstr.length;
+  const u8arr = new Uint8Array(n);
+  while (n--) u8arr[n] = bstr.charCodeAt(n);
+  return new Blob([u8arr], { type: mime });
+}

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import styled, { css } from "styled-components";
-import BoiniSymbol from "../assets/images/Boini_logo.svg";
 import TitleSVG from "../assets/images/title.svg";
 import Emoji1 from "../assets/images/emoji1.svg";
 import Emoji2 from "../assets/images/emoji2.svg";

--- a/src/pages/PresenterView/PresenterViewPage.jsx
+++ b/src/pages/PresenterView/PresenterViewPage.jsx
@@ -1,11 +1,12 @@
-import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
+// src/pages/Presentation/PresenterViewPage.jsx
+import React, { useState, useEffect } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
 import Layout from "../../components/Layout/LayoutContainer";
 import SidebarSlides from "../../components/SidebarSlides";
 import SlideViewer from "../../components/SlideViewer";
 import QuestionList from "../../components/QuestionList";
 
-// SettingsPanel 스타일과 구성 요소 재사용
+// SettingsPanel 스타일 재사용
 import {
     PanelWrapper,
     Section,
@@ -23,43 +24,116 @@ import AudienceSVG from "../../assets/images/people.svg";
 
 const PresenterViewPage = () => {
     const navigate = useNavigate();
-    const [currentSlide, setCurrentSlide] = useState(0);
+    const location = useLocation();
+    const { roomId, deckId, totalPages } = location.state || {};
 
-    // ✅ UI 테스트용 더미 슬라이드 이미지
-    const dummySlides = [
-        "https://picsum.photos/seed/slide1/1280/720",
-        "https://picsum.photos/seed/slide2/1280/720",
-        "https://picsum.photos/seed/slide3/1280/720",
-        "https://picsum.photos/seed/slide4/1280/720",
-    ];
+    const [currentSlide, setCurrentSlide] = useState(0);
+    const [thumbnails, setThumbnails] = useState([]);
+    const [loading, setLoading] = useState(true);
+
+    // ✅ 서버 이미지 경로 직접 조합해서 불러오기
+    useEffect(() => {
+        if (!roomId || !deckId || !totalPages) {
+            console.warn("⚠️ [PresenterViewPage] 필수 파라미터 누락:", {
+                roomId,
+                deckId,
+                totalPages,
+            });
+            setLoading(false);
+            return;
+        }
+
+        const loadSlides = async () => {
+            try {
+                console.log("🖼️ [PresenterViewPage] 슬라이드 경로 생성 시작:", {
+                    roomId,
+                    deckId,
+                    totalPages,
+                });
+
+                // ✅ totalPages만큼 슬라이드 경로 생성
+                const slideUrls = Array.from({ length: totalPages }, (_, i) => ({
+                    page: i + 1,
+                    thumbnailUrl: `/api/presentations/${roomId}/${deckId}/pages/${i + 1
+                        }?ext=png`,
+                }));
+
+                setThumbnails(slideUrls);
+                console.log("✅ [PresenterViewPage] 슬라이드 URL 자동 생성 완료:", {
+                    slideCount: slideUrls.length,
+                });
+            } catch (err) {
+                console.error("❌ [PresenterViewPage] 슬라이드 생성 실패:", err);
+                setThumbnails([]);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        loadSlides();
+    }, [roomId, deckId, totalPages]);
 
     const handleEndSession = () => {
         alert("세션이 종료되었습니다!");
         navigate("/");
     };
 
+    // ✅ 로딩 중일 때 표시
+    if (loading) {
+        return (
+            <Layout>
+                <div
+                    style={{
+                        display: "flex",
+                        justifyContent: "center",
+                        alignItems: "center",
+                        height: "100vh",
+                    }}
+                >
+                    <p>슬라이드 로딩 중...</p>
+                </div>
+            </Layout>
+        );
+    }
+
+    // ✅ 썸네일이 없을 때 표시
+    if (!thumbnails.length) {
+        return (
+            <Layout>
+                <div
+                    style={{
+                        display: "flex",
+                        justifyContent: "center",
+                        alignItems: "center",
+                        height: "100vh",
+                    }}
+                >
+                    <p>슬라이드를 불러올 수 없습니다.</p>
+                </div>
+            </Layout>
+        );
+    }
+
     return (
         <Layout>
-            {/* 좌측: 슬라이드 썸네일 */}
+            {/* 🔹 좌측: 슬라이드 썸네일 리스트 */}
             <SidebarSlides
-                slides={dummySlides}
+                slides={thumbnails}
                 currentSlide={currentSlide}
                 setCurrentSlide={setCurrentSlide}
-                participantCount={3}
-                maxParticipants={50}
             />
 
-            {/* 중앙: 현재 슬라이드 */}
+            {/* 🔹 중앙: 현재 슬라이드 */}
             <SlideViewer
-                slides={dummySlides}
+                slides={thumbnails}
                 currentSlide={currentSlide}
                 setCurrentSlide={setCurrentSlide}
                 mode="present"
             />
 
-            {/* 우측: 빠른 설정 + 실시간 질문 */}
+            {/* 🔹 우측: 빠른 설정 + 실시간 질문 */}
             <PanelWrapper>
-                {/* 🧩 빠른 설정 섹션 */}
+                {/* === 빠른 설정 섹션 === */}
                 <Section>
                     <Title>빠른 설정</Title>
                     <AudienceCountWrapper>
@@ -88,7 +162,7 @@ const PresenterViewPage = () => {
                     </QuickTogglesGrid>
                 </Section>
 
-                {/* 실시간 질문 섹션 (LiveWaitingBox → QuestionList 대체) */}
+                {/* === 실시간 질문 섹션 === */}
                 <Section>
                     <Title>실시간 질문</Title>
                     <QuestionList onEndSession={handleEndSession} />
@@ -100,7 +174,7 @@ const PresenterViewPage = () => {
 
 export default PresenterViewPage;
 
-// ✅ SettingsPanel의 toggle 요소 재활용
+// ✅ 빠른 설정 토글 UI
 const QuickSettingToggle = ({ label, description }) => (
     <ToggleBox>
         <ToggleLabel>{label}</ToggleLabel>

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -8,4 +8,26 @@ const api = axios.create({
     },
 });
 
+// 요청 인터셉터: FormData 처리
+api.interceptors.request.use(
+    (config) => {
+        // FormData를 보낼 때는 Content-Type 헤더를 제거하여 axios가 자동으로 boundary를 설정하도록 함
+        if (config.data instanceof FormData) {
+            delete config.headers["Content-Type"];
+            console.log(" [API Interceptor] FormData 감지 - Content-Type 헤더 제거 (자동 boundary 설정)");
+            
+            // FormData 필드명 확인
+            const entries = Array.from(config.data.entries());
+            const fieldNames = [...new Set(entries.map(([key]) => key))];
+            console.log(" [API Interceptor] FormData 필드명:", fieldNames);
+        }
+        
+        return config;
+    },
+    (error) => {
+        console.error("[API 요청 에러]", error);
+        return Promise.reject(error);
+    }
+);
+
 export default api;

--- a/src/services/presentationService.js
+++ b/src/services/presentationService.js
@@ -1,0 +1,34 @@
+import api from "./api";
+
+export const fetchSlidesMeta = async (roomId, deckId, totalPages) => {
+    try {
+        console.log("📥 [fetchSlidesMeta] 슬라이드 메타 정보 요청:", {
+            roomId,
+            deckId,
+            totalPages,
+            endpoint: `/api/presentations/${roomId}/${deckId}/meta`,
+        });
+
+        const res = await api.get(`/api/presentations/${roomId}/${deckId}/meta`, {
+            params: { totalPages },
+        });
+
+        console.log("✅ [fetchSlidesMeta] 슬라이드 메타 정보 가져오기 성공:", {
+            status: res.status,
+            responseData: res.data,
+            extractedData: res.data.data,
+            thumbnailCount: res.data.data?.thumbnailUrl?.length || 0,
+        });
+
+        return res.data.data; // { roomId, deckId, totalPages, thumbnailUrl: [...] }
+    } catch (err) {
+        console.error("❌ [fetchSlidesMeta] 슬라이드 메타 정보 가져오기 실패:", {
+            error: err,
+            message: err.message,
+            status: err.response?.status,
+            responseData: err.response?.data,
+        });
+        throw err;
+    }
+};
+

--- a/src/services/roomService.js
+++ b/src/services/roomService.js
@@ -1,9 +1,31 @@
 import api from "./api";
 
 export const createRoom = async (totalPages = 10) => {
-    const res = await api.post("/api/rooms", {
+    const requestData = {
         count: 50, //50 하드코딩
         totalPages,
+    };
+    
+    console.log("[createRoom] 방 생성 요청:", {
+        endpoint: "/api/rooms",
+        requestData,
     });
-    return res.data.data;
+    
+    try {
+        const res = await api.post("/api/rooms", requestData);
+        
+        console.log("[createRoom] 방 생성 응답:", {
+            status: res.status,
+            responseData: res.data,
+            extractedData: res.data.data,
+        });
+        
+        return res.data.data;
+    } catch (error) {
+        console.error("[createRoom] 방 생성 실패:", {
+            error,
+            requestData,
+        });
+        throw error;
+    }
 };


### PR DESCRIPTION
## ✨ 작업 개요

- 발표 준비/ 진행 페이지 api 연결
- 발표 진행 페이지에서도 파일명 정상 표시되도록 수정
- 공유하기 버튼 눌렀을 시 방 생성이 아니라, pdf 업로드 후 이미지 변환한 다음 자동으로 방 생성되도록 수정
- 이후 roomId가 준비되면 프론트는 변환된 슬라이드 이미지를 서버에 업로드하고, 서버는 각 페이지의 이미지 접근 URL(/pages/{page}?ext=png)을 응답으로 줌