### PR TITLE
슬라이드 POST&GET 연결 완료

### DIFF
--- a/src/components/HeaderBar/index.jsx
+++ b/src/components/HeaderBar/index.jsx
@@ -1,10 +1,9 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styled, { css } from "styled-components";
 import { useLocation, useNavigate, useMatch } from "react-router-dom";
 import BoiniLogo from "../../assets/images/Boini_logo.svg";
 import LiveIcon from "../../assets/images/live.png";
 import ShareModal from "../modal/ShareModal";
-import useRoom from "../../hooks/useRoom";
 import {
   ShareButton,
   ExitButton,
@@ -96,7 +95,7 @@ const RightActions = styled.div`
   margin-right: 1vw;
 `;
 
-function HeaderBar() {
+function HeaderBar({ roomData: propRoomData, totalPages }) {
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -104,26 +103,44 @@ function HeaderBar() {
   const isRating = location.pathname === "/rating";
   const isAiReport = location.pathname === "/ai-report";
   const isAudienceView = location.pathname === "/audience";
-  const isPrep = location.pathname === "/create-presentation";
-  const isPresenter = location.pathname === "/presentation";
+  const isPrep = location.pathname.startsWith("/create-presentation");
+  const isPresenter = location.pathname.startsWith("/presentation");
   const isCodeRoute = Boolean(useMatch(":code"));
-  const isAudienceLike = isAudienceView || isCodeRoute;
-
-  const fileName = location.state?.fileName;
-  const { slides, sessionId, features, maxParticipants } = location.state || {};
 
   const [showShareModal, setShowShareModal] = useState(false);
-  const { roomData, loading, initRoom } = useRoom();
+  const [roomData, setRoomData] = useState(propRoomData || null);
+  const [fileName, setFileName] = useState(location.state?.fileName || "");
 
+  /* ✅ 새로고침 또는 state 유실 시 sessionStorage 복구 */
+  useEffect(() => {
+    if (!roomData) {
+      const stored = sessionStorage.getItem("boini_room") || sessionStorage.getItem("roomData");
+      if (stored) {
+        setRoomData(JSON.parse(stored));
+      }
+    }
+  }, [roomData]);
+
+  useEffect(() => {
+    if (!fileName && location.state?.fileName) {
+      setFileName(location.state.fileName);
+    }
+  }, [location.state]);
+
+  /* ✅ 세션 시작 / 종료 버튼 */
   const handleSessionAction = () => {
     if (isPrep) {
-      navigate("/presentation", {
+      if (!roomData?.roomId || !roomData?.deckId) {
+        alert("⚠️ 방 정보가 아직 준비되지 않았습니다.");
+        return;
+      }
+
+      navigate(`/presentation/${roomData.roomId}`, {
         state: {
-          slides,
-          sessionId,
-          features,
-          maxParticipants,
           fileName,
+          roomId: roomData.roomId,
+          deckId: roomData.deckId,
+          totalPages: totalPages || 0,
         },
       });
     } else if (isPresenter) {
@@ -131,9 +148,11 @@ function HeaderBar() {
     }
   };
 
-  const handleShareClick = async () => {
-    if (!roomData) {
-      await initRoom(slides?.length || 10);
+
+  const handleShareClick = () => {
+    if (!roomData || !roomData.joinUrl) {
+      alert("⚠️ 방 정보가 없습니다. 발표 준비 완료 후 다시 시도해주세요.");
+      return;
     }
     setShowShareModal(true);
   };
@@ -162,7 +181,7 @@ function HeaderBar() {
         {(isAudienceView || isPrep || isPresenter || isAiReport) && (
           <RightActions>
             {(isAudienceView || isPrep || isPresenter) && (
-              <ShareButton onClick={handleShareClick} disabled={loading} />
+              <ShareButton onClick={handleShareClick} />
             )}
 
             {(isPrep || isPresenter) && (
@@ -178,8 +197,7 @@ function HeaderBar() {
 
       {showShareModal && roomData && (
         <ShareModal
-          sessionLink={roomData.joinUrl}
-          qrBase64={roomData.qrPngBase64}
+          roomData={roomData}
           onClose={() => setShowShareModal(false)}
         />
       )}

--- a/src/components/Layout/Layout.jsx
+++ b/src/components/Layout/Layout.jsx
@@ -1,4 +1,3 @@
-// src/components/Layout/Layout.jsx
 import React from "react";
 import HeaderBar from "../HeaderBar";
 import { LayoutContainer } from "./Layout.styles";
@@ -7,6 +6,7 @@ const Layout = ({ children, headerProps = {} }) => {
     return (
         <LayoutContainer style={{ flexDirection: "column" }}>
             <HeaderBar
+                roomData={headerProps.roomData} 
                 roomId={headerProps.roomId}
                 deckId={headerProps.deckId}
                 totalPages={headerProps.totalPages}

--- a/src/hooks/usePdfConverter.js
+++ b/src/hooks/usePdfConverter.js
@@ -1,47 +1,45 @@
 // src/hooks/usePdfConverter.js
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import * as pdfjsLib from "pdfjs-dist";
 import pdfWorker from "pdfjs-dist/build/pdf.worker.min?url";
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = pdfWorker;
 
 export default function usePdfConverter() {
-    const [slides, setSlides] = useState([]);
-    const [loading, setLoading] = useState(false);
-    const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
-    const convertPdfToImages = async (file) => {
-        try {
-            setLoading(true);
-            setError(null);
+  const convertPdfToImages = useCallback(async (file) => {
+    if (!file) return [];
+    try {
+      setLoading(true);
+      setError(null);
 
-            const arrayBuffer = await file.arrayBuffer();
-            const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
-            const imgs = [];
+      const arrayBuffer = await file.arrayBuffer();
+      const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
+      const imgs = [];
 
-            // ✅ 화질 개선: scale 2.5 (기존 1.5보다 고해상도)
-            for (let i = 1; i <= pdf.numPages; i++) {
-                const page = await pdf.getPage(i);
-                const viewport = page.getViewport({ scale: 2.5 });
-                const canvas = document.createElement("canvas");
-                const ctx = canvas.getContext("2d");
+      
+      for (let i = 1; i <= pdf.numPages; i++) {
+        const page = await pdf.getPage(i);
+        const viewport = page.getViewport({ scale: 2.5 });
+        const canvas = document.createElement("canvas");
+        const ctx = canvas.getContext("2d");
 
-                canvas.width = viewport.width;
-                canvas.height = viewport.height;
+        canvas.width = viewport.width;
+        canvas.height = viewport.height;
 
-                await page.render({ canvasContext: ctx, viewport }).promise;
-                imgs.push(canvas.toDataURL("image/png"));
-            }
+        await page.render({ canvasContext: ctx, viewport }).promise;
+        imgs.push(canvas.toDataURL("image/png"));
+      }
+      return imgs;
+    } catch (err) {
+      setError(err.message);
+      return [];
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
-            // ✅ 비동기 안정화 (state 업데이트 타이밍 보장)
-            await new Promise((resolve) => setTimeout(resolve, 0));
-            setSlides(imgs);
-        } catch (err) {
-            setError(err.message);
-        } finally {
-            setLoading(false);
-        }
-    };
-
-    return { slides, setSlides, loading, error, convertPdfToImages };
+  return { loading, error, convertPdfToImages };
 }

--- a/src/pages/CreateSession/CreateSessionPage.jsx
+++ b/src/pages/CreateSession/CreateSessionPage.jsx
@@ -1,13 +1,11 @@
-import React, { useState, useEffect } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import React, { useState, useEffect, useRef } from "react";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { v4 as uuidv4 } from "uuid";
 import usePdfConverter from "../../hooks/usePdfConverter";
 import { createRoom } from "../../services/roomService";
+import { fetchAllOriginalSlideUrls } from "../../services/presentationService";
 import api from "../../services/api";
-
-// 🔹 HeaderBar 포함 Layout 사용 (새로운 Layout.jsx)
 import Layout from "../../components/Layout/Layout";
-
 import SidebarSlides from "../../components/SidebarSlides";
 import SlideViewer from "../../components/SlideViewer";
 import SettingsPanel from "../../components/SettingsPanel";
@@ -17,77 +15,116 @@ import ShareModal from "../../components/modal/ShareModal";
 const PresentationPrepPage = () => {
   const location = useLocation();
   const navigate = useNavigate();
+  const { roomId: roomIdParam } = useParams();
   const { pdfFile } = location.state || {};
 
   const [currentSlide, setCurrentSlide] = useState(0);
-  const [roomId, setRoomId] = useState(null);
   const [roomData, setRoomData] = useState(null);
-  const [deckId] = useState(uuidv4());
-  const [isShareModalOpen, setIsShareModalOpen] = useState(false);
+  const [deckId, setDeckId] = useState(null);
+  const [slideImageFiles, setSlideImageFiles] = useState([]);
+  const [slideUrls, setSlideUrls] = useState([]);
   const [imagesLoaded, setImagesLoaded] = useState(false);
 
-  const { slides, setSlides, convertPdfToImages } = usePdfConverter();
+  const hasInitializedRef = useRef(false);
 
+  const { convertPdfToImages } = usePdfConverter();
+
+  // 1. PDF → 이미지 변환
   useEffect(() => {
     if (pdfFile) {
-      convertPdfToImages(pdfFile);
+      convertPdfToImages(pdfFile).then(setSlideImageFiles);
     } else {
       navigate("/");
     }
-  }, [pdfFile]);
+  }, [pdfFile, navigate, convertPdfToImages]);
 
+  // 2. 이미지 업로드 + 방 생성
   useEffect(() => {
-    if (!slides || slides.length === 0) return;
+    if (!slideImageFiles || slideImageFiles.length === 0) {
+      return;
+    }
 
-    const initRoom = async () => {
+    if (hasInitializedRef.current) {
+      return;
+    }
+
+    const initRoomAndUpload = async () => {
       try {
-        const room = await createRoom(slides.length);
-        setRoomId(room.roomId);
+        hasInitializedRef.current = true;
+        console.log("📄 변환된 슬라이드 개수:", slideImageFiles.length);
+
+        // 1️⃣ 방 생성
+        const room = await createRoom(slideImageFiles.length);
+        console.log("🏠 방 생성 완료:", room);
+        const { roomId, deckId: serverDeckId } = room;
+        setDeckId(serverDeckId);
+
+        // 2️⃣ 이미지 업로드 (API 명세에 맞게 한번에 전송)
+        const formData = new FormData();
+        slideImageFiles.forEach((dataUrl, idx) => {
+          const blob = dataURLtoBlob(dataUrl);
+          // API 명세에 따라 필드명을 'files'로 지정
+          formData.append("files", blob, `page_${idx + 1}.png`);
+        });
+
+        const uploadRes = await api.post(
+          `/api/presentations/${roomId}/${serverDeckId}/pages`,
+          formData
+        );
+        console.log("📤 슬라이드 업로드 완료:", uploadRes.data);
+
+        // 3️⃣ Presigned URL로 원본 슬라이드 불러오기
+        console.log("🔹 fetchAllOriginalSlideUrls 호출 인자:", {
+          roomId,
+          deckId: serverDeckId,
+          totalPages: slideImageFiles.length,
+        });
+        const originalUrls = await fetchAllOriginalSlideUrls(
+          roomId,
+          serverDeckId,
+          slideImageFiles.length
+        );
+        
+
+        // 4️⃣ 상태 저장 + sessionStorage
+        setSlideUrls(originalUrls);
         setRoomData(room);
-        console.log("🏠 방 생성 완료:", room.roomId);
-      } catch {
-        alert("방 생성 중 오류가 발생했습니다.");
-      }
-    };
+        sessionStorage.setItem(
+          "boini_room",
+          JSON.stringify({ ...room, deckId: serverDeckId })
+        );
+        sessionStorage.setItem(
+          "roomData",
+          JSON.stringify({ ...room, deckId: serverDeckId })
+        );
 
-    initRoom();
-  }, [slides.length, deckId]);
+        if (roomIdParam !== roomId) {
+          navigate(`/create-presentation/${roomId}`, {
+            replace: true,
+            state: location.state,
+          });
+        }
 
-  useEffect(() => {
-    const uploadSlides = async () => {
-      if (!roomId || !slides || slides.length === 0) return;
-
-      const formData = new FormData();
-      slides.forEach((dataUrl, idx) => {
-        const blob = dataURLtoBlob(dataUrl);
-        formData.append("files", blob, `page_${idx + 1}.png`);
-      });
-
-      try {
-        const res = await api.post(`/api/presentations/${roomId}/${deckId}/pages`, formData);
-        console.log(" 업로드 성공:", res.data);
-
-        const totalPages = res.data?.data?.totalPages || slides.length;
-        const slideUrls = Array.from({ length: totalPages }, (_, i) => ({
-          page: i + 1,
-          thumbnailUrl: `/api/presentations/${roomId}/${deckId}/pages/${i + 1}?ext=png`,
-        }));
-
-        setSlides(slideUrls);
-        console.log("서버 경로 기반 slides 생성 완료:", slideUrls);
+        console.log(" 세션 초기화 완료");
       } catch (err) {
-        console.error("❌ 슬라이드 업로드 실패:", err);
+        hasInitializedRef.current = false;
+        console.error("❌ [initRoomAndUpload] 세션 초기화 실패:", {
+          name: err.name,
+          message: err.message,
+          stack: err.stack,
+          response: err.response?.data,
+        });
       }
     };
 
-    uploadSlides();
-  }, [roomId, slides, deckId]);
+    initRoomAndUpload();
+  }, [slideImageFiles, navigate, roomIdParam, pdfFile]);
 
-
+  // 3. 슬라이드 이미지 로딩 확인
   useEffect(() => {
-    if (!slides || slides.length === 0) return;
+    if (!slideUrls || slideUrls.length === 0) return;
 
-    const loadPromises = slides.map((slide) => {
+    const loadPromises = slideUrls.map((slide) => {
       return new Promise((resolve) => {
         const img = new Image();
         img.src = slide.thumbnailUrl || slide;
@@ -100,44 +137,39 @@ const PresentationPrepPage = () => {
       setImagesLoaded(true);
       console.log("🖼️ 모든 슬라이드 이미지 로드 완료");
     });
-  }, [slides]);
+  }, [slideUrls]);
 
-  if (!slides || slides.length === 0 || !imagesLoaded)
+  if (!slideUrls || slideUrls.length === 0 || !imagesLoaded)
     return <LandingPage message="세션 자료 준비 중..." />;
 
   return (
     <Layout
       headerProps={{
-        roomId,
-        deckId,
-        totalPages: slides.length,
+        roomId: roomData?.roomId,
+        deckId: deckId || roomData?.deckId,
+        totalPages: slideUrls.length,
+        roomData,
       }}
     >
       <SidebarSlides
-        slides={slides}
+        slides={slideUrls}
         currentSlide={currentSlide}
         setCurrentSlide={setCurrentSlide}
       />
       <SlideViewer
-        slides={slides}
+        slides={slideUrls}
         currentSlide={currentSlide}
         setCurrentSlide={setCurrentSlide}
         mode="prepare"
       />
       <SettingsPanel />
-
-      {isShareModalOpen && (
-        <ShareModal
-          roomData={roomData}
-          onClose={() => setIsShareModalOpen(false)}
-        />
-      )}
     </Layout>
   );
 };
 
 export default PresentationPrepPage;
 
+// 유틸: dataURL → Blob 변환
 function dataURLtoBlob(dataUrl) {
   const arr = dataUrl.split(",");
   const mime = arr[0].match(/:(.*?);/)[1];

--- a/src/pages/PresenterView/PresenterViewPage.jsx
+++ b/src/pages/PresenterView/PresenterViewPage.jsx
@@ -1,10 +1,11 @@
 // src/pages/Presentation/PresenterViewPage.jsx
 import React, { useState, useEffect } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
-import Layout from "../../components/Layout/LayoutContainer";
+import { useNavigate, useLocation, useParams } from "react-router-dom";
+import Layout from "../../components/Layout/Layout"; // ✅ LayoutContainer 말고 이거
 import SidebarSlides from "../../components/SidebarSlides";
 import SlideViewer from "../../components/SlideViewer";
 import QuestionList from "../../components/QuestionList";
+import { fetchAllOriginalSlideUrls } from "../../services/presentationService";
 
 // SettingsPanel 스타일 재사용
 import {
@@ -25,13 +26,24 @@ import AudienceSVG from "../../assets/images/people.svg";
 const PresenterViewPage = () => {
     const navigate = useNavigate();
     const location = useLocation();
-    const { roomId, deckId, totalPages } = location.state || {};
+    const { roomId: roomIdParam } = useParams();
+
+    const storedRoomData = JSON.parse(
+        sessionStorage.getItem("boini_room") ||
+            sessionStorage.getItem("roomData") ||
+            "{}"
+    );
+
+    const roomId = roomIdParam || location.state?.roomId || storedRoomData.roomId;
+    const deckId = location.state?.deckId || storedRoomData.deckId;
+    const totalPages =
+        location.state?.totalPages || storedRoomData.totalPages || 0;
 
     const [currentSlide, setCurrentSlide] = useState(0);
-    const [thumbnails, setThumbnails] = useState([]);
+    const [slideUrls, setSlideUrls] = useState([]);
     const [loading, setLoading] = useState(true);
 
-    // ✅ 서버 이미지 경로 직접 조합해서 불러오기
+    // 서버에서 presigned URL 하나씩 가져와서 썸네일로 사용
     useEffect(() => {
         if (!roomId || !deckId || !totalPages) {
             console.warn("⚠️ [PresenterViewPage] 필수 파라미터 누락:", {
@@ -43,34 +55,42 @@ const PresenterViewPage = () => {
             return;
         }
 
-        const loadSlides = async () => {
+        const fetchSlides = async () => {
             try {
-                console.log("🖼️ [PresenterViewPage] 슬라이드 경로 생성 시작:", {
+                console.log("🖼️ [PresenterViewPage] 슬라이드 URL 가져오기 시작:", {
                     roomId,
                     deckId,
                     totalPages,
                 });
 
-                // ✅ totalPages만큼 슬라이드 경로 생성
-                const slideUrls = Array.from({ length: totalPages }, (_, i) => ({
-                    page: i + 1,
-                    thumbnailUrl: `/api/presentations/${roomId}/${deckId}/pages/${i + 1
-                        }?ext=png`,
-                }));
+                const urls = await fetchAllOriginalSlideUrls(
+                    roomId,
+                    deckId,
+                    totalPages
+                );
 
-                setThumbnails(slideUrls);
-                console.log("✅ [PresenterViewPage] 슬라이드 URL 자동 생성 완료:", {
-                    slideCount: slideUrls.length,
+                urls.forEach((url, index) => {
+                    console.log(
+                        `[PresenterViewPage] 슬라이드 ${index + 1}번 URL:`,
+                        url
+                    );
+                });
+
+                // CreateSessionPage와 동일하게, URL 문자열 배열을 그대로 사용합니다.
+                setSlideUrls(urls);
+
+                console.log("✅ [PresenterViewPage] 슬라이드 URL 생성 완료:", {
+                    slideCount: urls.length,
                 });
             } catch (err) {
                 console.error("❌ [PresenterViewPage] 슬라이드 생성 실패:", err);
-                setThumbnails([]);
+                setSlideUrls([]);
             } finally {
                 setLoading(false);
             }
         };
 
-        loadSlides();
+        fetchSlides();
     }, [roomId, deckId, totalPages]);
 
     const handleEndSession = () => {
@@ -96,8 +116,8 @@ const PresenterViewPage = () => {
         );
     }
 
-    // ✅ 썸네일이 없을 때 표시
-    if (!thumbnails.length) {
+    // 썸네일이 없을 때 표시
+    if (!slideUrls.length) { // 이 부분을 slideUrls로 변경
         return (
             <Layout>
                 <div
@@ -118,14 +138,14 @@ const PresenterViewPage = () => {
         <Layout>
             {/* 🔹 좌측: 슬라이드 썸네일 리스트 */}
             <SidebarSlides
-                slides={thumbnails}
+                slides={slideUrls} // 이 부분을 slideUrls로 변경
                 currentSlide={currentSlide}
                 setCurrentSlide={setCurrentSlide}
             />
 
             {/* 🔹 중앙: 현재 슬라이드 */}
             <SlideViewer
-                slides={thumbnails}
+                slides={slideUrls} // 이 부분을 slideUrls로 변경
                 currentSlide={currentSlide}
                 setCurrentSlide={setCurrentSlide}
                 mode="present"
@@ -174,7 +194,7 @@ const PresenterViewPage = () => {
 
 export default PresenterViewPage;
 
-// ✅ 빠른 설정 토글 UI
+// 빠른 설정 토글 UI
 const QuickSettingToggle = ({ label, description }) => (
     <ToggleBox>
         <ToggleLabel>{label}</ToggleLabel>

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -21,7 +21,11 @@ const router = createBrowserRouter([
         element: <CreateSessionPage />,
       },
       {
-        path: "presentation",
+        path: "create-presentation/:roomId",
+        element: <CreateSessionPage />,
+      },
+      {
+        path: "presentation/:roomId",
         element: <PresenterViewPage />,
       },
       {

--- a/src/services/fetchSlides.js
+++ b/src/services/fetchSlides.js
@@ -1,0 +1,18 @@
+import api from "./api";
+
+export const fetchSlideUrls = async (roomId, deckId, totalPages) => {
+    try {
+        const slides = await Promise.all(
+            Array.from({ length: totalPages }, async (_, i) => {
+                const page = i + 1;
+                const res = await api.get(`/api/presentations/${roomId}/${deckId}/pages/${page}?ext=png`);
+                return { page, thumbnailUrl: res.data.data.originalUrl };
+            })
+        );
+        console.log("✅ [fetchSlideUrls] 슬라이드 URL 목록 생성 완료:", slides);
+        return slides;
+    } catch (err) {
+        console.error("❌ [fetchSlideUrls] 슬라이드 URL 생성 실패:", err);
+        return [];
+    }
+};

--- a/src/services/presentationService.js
+++ b/src/services/presentationService.js
@@ -1,34 +1,43 @@
 import api from "./api";
 
-export const fetchSlidesMeta = async (roomId, deckId, totalPages) => {
-    try {
-        console.log("📥 [fetchSlidesMeta] 슬라이드 메타 정보 요청:", {
-            roomId,
-            deckId,
-            totalPages,
-            endpoint: `/api/presentations/${roomId}/${deckId}/meta`,
-        });
+/**
+ * 특정 페이지의 원본 이미지 URL(Presigned URL)을 가져옵니다.
+ * @param {string} roomId - 방 ID
+ * @param {string} deckId - 덱 ID
+ * @param {number} page - 페이지 번호 (1-based)
+ * @returns {Promise<string>} 원본 이미지 URL
+ */
+export const getOriginalSlideUrl = async (roomId, deckId, page) => {
+  try {
+    const response = await api.get(
+      `/api/presentations/${roomId}/${deckId}/pages/${page}?ext=png`
+    );
+    return response.data.data.originalUrl;
+  } catch (error) {
+    console.error(`Error fetching original slide for page ${page}:`, error);
+    throw error;
+  }
+};
 
-        const res = await api.get(`/api/presentations/${roomId}/${deckId}/meta`, {
-            params: { totalPages },
-        });
-
-        console.log("✅ [fetchSlidesMeta] 슬라이드 메타 정보 가져오기 성공:", {
-            status: res.status,
-            responseData: res.data,
-            extractedData: res.data.data,
-            thumbnailCount: res.data.data?.thumbnailUrl?.length || 0,
-        });
-
-        return res.data.data; // { roomId, deckId, totalPages, thumbnailUrl: [...] }
-    } catch (err) {
-        console.error("❌ [fetchSlidesMeta] 슬라이드 메타 정보 가져오기 실패:", {
-            error: err,
-            message: err.message,
-            status: err.response?.status,
-            responseData: err.response?.data,
-        });
-        throw err;
+/**
+ * 모든 페이지의 원본 이미지 URL을 가져옵니다.
+ * @param {string} roomId - 방 ID
+ * @param {string} deckId - 덱 ID
+ * @param {number} totalPages - 전체 페이지 수
+ * @returns {Promise<string[]>} 모든 원본 이미지 URL 배열
+ */
+export const fetchAllOriginalSlideUrls = async (roomId, deckId, totalPages) => {
+  try {
+    const urlPromises = [];
+    // 페이지 번호는 1부터 시작
+    for (let i = 1; i <= totalPages; i++) {
+      urlPromises.push(getOriginalSlideUrl(roomId, deckId, i));
     }
+    const urls = await Promise.all(urlPromises);
+    return urls;
+  } catch (error) {
+    console.error("Error fetching all original slide URLs:", error);
+    throw error;
+  }
 };
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    port: 5174,
+  },
   optimizeDeps: {
     include: ['pdfjs-dist']
   },


### PR DESCRIPTION
## ✨ 작업 개요

- 발표 준비 페이지와 발표 진행 페이지에 roomId 라우팅을 적용하고, 방 생성  한 번만 실행되도록 안정화

## ✅ 주요 작업 내용

- 발표 준비/진행 페이지가 roomId 파라미터를 사용하는 라우트로 동작하도록 구현
- 방 생성 후 서버가 반환한 roomId, deckId를 사용해 슬라이드 업로드·조회가 일관되게 이뤄지도록 API 연동
\