### PR TITLE
feat(audience): show ended screen for late joiners

### DIFF
--- a/src/pages/audience-room/ui/AudienceRoomPage.tsx
+++ b/src/pages/audience-room/ui/AudienceRoomPage.tsx
@@ -23,6 +23,7 @@ import {
   audienceTokenAtom,
 } from "../model";
 import DelayAudience from "./DelayAudience";
+import SessionEndedAudience from "./SessionEndedAudience";
 import { roomIdAtom, deckIdAtom, totalPagesAtom, wsUrlAtom } from "@/entities/room";
 import { quickSettingsAtom, unlockSettingsAtom } from "@/entities/session";
 
@@ -175,6 +176,7 @@ const AudienceRoomPage = () => {
 
   const isQuestionListWaiting = questionsLoading && questions.length === 0;
   const isSessionWaiting = sessionStatus === "waiting";
+  const isSessionEnded = sessionStatus === "ended" || sessionStatus === "ENDED";
 
   useEffect(() => {
     if (hasShownAudienceJoinWarningRef.current) return;
@@ -309,6 +311,12 @@ const AudienceRoomPage = () => {
       await fullscreenElement.webkitRequestFullscreen();
     }
   };
+
+  // Audience opened the session URL after it already ended: same layout as the
+  // "live waiting" screen, only the message differs.
+  if (isSessionEnded) {
+    return <SessionEndedAudience placeholderCount={totalPages || 10} />;
+  }
 
   if (isSessionWaiting) {
     return (

--- a/src/pages/audience-room/ui/SessionEndedAudience.tsx
+++ b/src/pages/audience-room/ui/SessionEndedAudience.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import delayImage from "@/shared/assets/images/delay.png";
+import {
+  PageContainer,
+  CenterContainer,
+  WaitingImage,
+  WaitingMessage,
+} from "./DelayAudience.styles";
+
+// Shown when an audience opens the session URL after it has already ended.
+// Mirrors the "live waiting" screen layout, only the message differs.
+const SessionEndedAudience = ({ placeholderCount = 12 }) => {
+  return (
+    <PageContainer>
+      <CenterContainer>
+        <WaitingImage src={delayImage} alt="세션 종료" />
+        <WaitingMessage>이미 종료된 세션입니다.</WaitingMessage>
+      </CenterContainer>
+    </PageContainer>
+  );
+};
+
+export default SessionEndedAudience;

--- a/src/widgets/app-header/ui/header/AppHeader.tsx
+++ b/src/widgets/app-header/ui/header/AppHeader.tsx
@@ -259,12 +259,16 @@ function AppHeader({ roomData: propRoomData, totalPages }: AppHeaderProps) {
 
         {!isMain && (
           <Body>
-            {isAudienceView && sessionStatus !== "waiting" && (
-              <LiveBadge>
-                <img src={LiveIcon} alt="live" />
-                라이브 진행 중
-              </LiveBadge>
-            )}
+            {isAudienceView &&
+              sessionStatus !== "waiting" &&
+              (sessionStatus === "ended" || sessionStatus === "ENDED" ? (
+                <LiveBadge>종료된 세션</LiveBadge>
+              ) : (
+                <LiveBadge>
+                  <img src={LiveIcon} alt="live" />
+                  라이브 진행 중
+                </LiveBadge>
+              ))}
             {(isPrep || isPresenter) && <FileName>{fileName || "파일명 없음"}</FileName>}
           </Body>
         )}


### PR DESCRIPTION
Audiences who open the session URL after it has already ended now see a dedicated SessionEndedAudience screen (same layout as the live-waiting screen, with an "이미 종료된 세션입니다." message) instead of the live room.

Also update the audience header badge to show "종료된 세션" (without the LIVE icon) instead of "라이브 진행 중" once the session has ended.