### PR TITLE
feat: mobile audience support + content-anchored reaction stickers

### DIFF
--- a/src/entities/reaction/ui/EmojiPanel/EmojiPanel.styles.ts
+++ b/src/entities/reaction/ui/EmojiPanel/EmojiPanel.styles.ts
@@ -20,11 +20,15 @@ export const EmojiContainer = styled.div`
   transform: translate(-50%, -50%);
   z-index: 10;
 
+  /* 모바일 오버레이(전체화면): 우측 종료 버튼을 가리지 않도록 좌우 오프셋 배치 */
   @media ${MEDIA.mobile} {
-    width: 100%;
+    width: auto;
     max-width: 100%;
     height: auto;
     padding: 6px 12px;
+    left: 12px;
+    right: 116px;
+    transform: translateY(-50%);
   }
 `;
 

--- a/src/entities/reaction/ui/EmojiPanel/EmojiPanel.styles.ts
+++ b/src/entities/reaction/ui/EmojiPanel/EmojiPanel.styles.ts
@@ -25,9 +25,9 @@ export const EmojiContainer = styled.div`
     width: auto;
     max-width: 100%;
     height: auto;
-    padding: 6px 12px;
+    padding: 4px 10px;
     left: 12px;
-    right: 116px;
+    right: 108px;
     transform: translateY(-50%);
   }
 `;
@@ -68,10 +68,10 @@ export const EmojiItem = styled.div`
     background-color: #e0e0e0;
   }
 
-  /* 터치 타깃 44px 확보 */
+  /* 터치 타깃 확보 */
   @media ${MEDIA.mobile} {
-    width: 44px;
-    height: 44px;
+    width: 40px;
+    height: 40px;
     flex-shrink: 0;
   }
 `;
@@ -83,8 +83,8 @@ export const EmojiIcon = styled.img`
   filter: grayscale(100%);
 
   @media ${MEDIA.mobile} {
-    width: 38px;
-    height: 38px;
+    width: 30px;
+    height: 30px;
   }
 `;
 

--- a/src/entities/reaction/ui/EmojiPanel/EmojiPanel.styles.ts
+++ b/src/entities/reaction/ui/EmojiPanel/EmojiPanel.styles.ts
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { MEDIA } from "@/shared/config/breakpoints";
 
 export const EmojiContainer = styled.div`
   width: 80%;
@@ -18,6 +19,13 @@ export const EmojiContainer = styled.div`
   left: 50%;
   transform: translate(-50%, -50%);
   z-index: 10;
+
+  @media ${MEDIA.mobile} {
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+    padding: 6px 12px;
+  }
 `;
 
 export const EmojiWrapper = styled.div`
@@ -27,6 +35,19 @@ export const EmojiWrapper = styled.div`
   width: 100%;
   height: 100%;
   gap: 0.42vw;
+
+  /* 모바일: 가로 스크롤 스트립 */
+  @media ${MEDIA.mobile} {
+    justify-content: flex-start;
+    gap: 8px;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
 `;
 
 export const EmojiItem = styled.div`
@@ -42,6 +63,13 @@ export const EmojiItem = styled.div`
   &:hover {
     background-color: #e0e0e0;
   }
+
+  /* 터치 타깃 44px 확보 */
+  @media ${MEDIA.mobile} {
+    width: 44px;
+    height: 44px;
+    flex-shrink: 0;
+  }
 `;
 
 export const EmojiIcon = styled.img`
@@ -49,6 +77,11 @@ export const EmojiIcon = styled.img`
   height: 48px;
   object-fit: contain;
   filter: grayscale(100%);
+
+  @media ${MEDIA.mobile} {
+    width: 38px;
+    height: 38px;
+  }
 `;
 
 export const SpacingBox = styled.div`

--- a/src/pages/ai-report/ui/sections/PopularSlide/PopularSlide.tsx
+++ b/src/pages/ai-report/ui/sections/PopularSlide/PopularSlide.tsx
@@ -78,6 +78,11 @@ const StampedSlideBox = ({
       {src ? (
         <>
           <img
+            key={src}
+            ref={(img) => {
+              // 캐시된 이미지는 onLoad 를 놓칠 수 있어 ref 시점에 complete 여부도 확인
+              if (img && img.complete) setNaturalRatio(imageNaturalRatio(img));
+            }}
             src={src}
             alt={alt}
             onLoad={(e: SyntheticEvent<HTMLImageElement>) =>

--- a/src/pages/ai-report/ui/sections/PopularSlide/PopularSlide.tsx
+++ b/src/pages/ai-report/ui/sections/PopularSlide/PopularSlide.tsx
@@ -8,6 +8,7 @@ import {
   SLIDE_BOX_ASPECT,
 } from "@/shared/lib/slide-geometry";
 import type { SlideContentFractions } from "@/shared/lib/slide-geometry";
+import { useElementAspectRatio } from "@/shared/lib/use-element-aspect-ratio";
 
 const log = createLogger("ai-report");
 import {
@@ -56,22 +57,8 @@ const StampedSlideBox = ({
   renderStamps: (fractions: SlideContentFractions) => ReactNode;
 }) => {
   const boxRef = useRef<HTMLDivElement | null>(null);
-  const [boxRatio, setBoxRatio] = useState<number>(SLIDE_BOX_ASPECT);
+  const boxRatio = useElementAspectRatio(boxRef);
   const [naturalRatio, setNaturalRatio] = useState<number | null>(null);
-
-  useEffect(() => {
-    const element = boxRef.current;
-    if (!element || typeof ResizeObserver === "undefined") return;
-
-    const measure = () => {
-      const rect = element.getBoundingClientRect();
-      if (rect.width > 0 && rect.height > 0) setBoxRatio(rect.width / rect.height);
-    };
-    measure();
-    const observer = new ResizeObserver(measure);
-    observer.observe(element);
-    return () => observer.disconnect();
-  }, []);
 
   return (
     <Box ref={boxRef}>
@@ -89,7 +76,7 @@ const StampedSlideBox = ({
               setNaturalRatio(imageNaturalRatio(e.currentTarget))
             }
           />
-          {renderStamps(slideContentFractions(naturalRatio, boxRatio))}
+          {renderStamps(slideContentFractions(naturalRatio, boxRatio ?? SLIDE_BOX_ASPECT))}
         </>
       ) : (
         <SlideSkeleton width="100%" height="100%" />

--- a/src/pages/ai-report/ui/sections/PopularSlide/PopularSlide.tsx
+++ b/src/pages/ai-report/ui/sections/PopularSlide/PopularSlide.tsx
@@ -1,5 +1,13 @@
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, useRef } from "react";
+import type { ComponentType, ReactNode, SyntheticEvent } from "react";
 import { createLogger } from "@/shared/lib/logger";
+import {
+  slideContentFractions,
+  stampBoxStyle,
+  imageNaturalRatio,
+  SLIDE_BOX_ASPECT,
+} from "@/shared/lib/slide-geometry";
+import type { SlideContentFractions } from "@/shared/lib/slide-geometry";
 
 const log = createLogger("ai-report");
 import {
@@ -33,6 +41,57 @@ interface ReactionSlideReportItem {
 interface EmojiOption {
   id: EmojiId;
 }
+
+/* 슬라이드 박스가 min-height 로 16:9 에서 벗어날 수 있어 실측 비율로 콘텐츠 영역을 계산,
+   레터박스를 제외한 실제 슬라이드 위에 스탬프를 배치한다 */
+const StampedSlideBox = ({
+  Box,
+  src,
+  alt,
+  renderStamps,
+}: {
+  Box: ComponentType<any>;
+  src: string | null;
+  alt: string;
+  renderStamps: (fractions: SlideContentFractions) => ReactNode;
+}) => {
+  const boxRef = useRef<HTMLDivElement | null>(null);
+  const [boxRatio, setBoxRatio] = useState<number>(SLIDE_BOX_ASPECT);
+  const [naturalRatio, setNaturalRatio] = useState<number | null>(null);
+
+  useEffect(() => {
+    const element = boxRef.current;
+    if (!element || typeof ResizeObserver === "undefined") return;
+
+    const measure = () => {
+      const rect = element.getBoundingClientRect();
+      if (rect.width > 0 && rect.height > 0) setBoxRatio(rect.width / rect.height);
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <Box ref={boxRef}>
+      {src ? (
+        <>
+          <img
+            src={src}
+            alt={alt}
+            onLoad={(e: SyntheticEvent<HTMLImageElement>) =>
+              setNaturalRatio(imageNaturalRatio(e.currentTarget))
+            }
+          />
+          {renderStamps(slideContentFractions(naturalRatio, boxRatio))}
+        </>
+      ) : (
+        <SlideSkeleton width="100%" height="100%" />
+      )}
+    </Box>
+  );
+};
 
 const EMOJI_NAMES: Record<number, string> = {
   1: "재미있는",
@@ -121,16 +180,13 @@ const PopularSlide = ({ roomId, deckId }: { roomId?: any; deckId?: any }) => {
   );
   const stampSrc = SELECTED_EMOJI_ICONS[selectedEmojiId as EmojiId];
 
-  const renderStamps = (stamps: SlideSticker[]) =>
+  const renderStamps = (stamps: SlideSticker[], fractions: SlideContentFractions) =>
     stampSrc
-      ? stamps.map((stamp) => (
-          <StampImage
-            key={stamp.id}
-            src={stampSrc}
-            alt="sticker"
-            style={{ top: `${stamp.yPct}%`, left: `${stamp.xPct}%` }}
-          />
-        ))
+      ? stamps.map((stamp) => {
+          // 위치만 콘텐츠 기준으로 보정하고, 크기는 리포트 고유 clamp 스타일 유지
+          const { left, top } = stampBoxStyle(stamp.xPct, stamp.yPct, fractions);
+          return <StampImage key={stamp.id} src={stampSrc} alt="sticker" style={{ left, top }} />;
+        })
       : null;
 
   return (
@@ -157,16 +213,12 @@ const PopularSlide = ({ roomId, deckId }: { roomId?: any; deckId?: any }) => {
             ) : (
               <>
                 <SlideWrapper>
-                  <LargeSlide>
-                    {firstSlideUrl ? (
-                      <>
-                        <img src={firstSlideUrl} alt="Most popular slide" />
-                        {renderStamps(firstSlideStamps)}
-                      </>
-                    ) : (
-                      <SlideSkeleton width="100%" height="100%" />
-                    )}
-                  </LargeSlide>
+                  <StampedSlideBox
+                    Box={LargeSlide}
+                    src={firstSlideUrl}
+                    alt="Most popular slide"
+                    renderStamps={(fractions) => renderStamps(firstSlideStamps, fractions)}
+                  />
                   <SlideNumber
                     slideNumber={
                       primarySlideNumber && primarySlideNumber > 0 ? primarySlideNumber : "-"
@@ -180,16 +232,12 @@ const PopularSlide = ({ roomId, deckId }: { roomId?: any; deckId?: any }) => {
                 </SlideWrapper>
                 {hasSecondSlide && (
                   <SlideWrapper>
-                    <SmallSlide>
-                      {secondSlideUrl ? (
-                        <>
-                          <img src={secondSlideUrl} alt="Second popular slide" />
-                          {renderStamps(secondSlideStamps)}
-                        </>
-                      ) : (
-                        <SlideSkeleton width="100%" height="100%" />
-                      )}
-                    </SmallSlide>
+                    <StampedSlideBox
+                      Box={SmallSlide}
+                      src={secondSlideUrl}
+                      alt="Second popular slide"
+                      renderStamps={(fractions) => renderStamps(secondSlideStamps, fractions)}
+                    />
                     <SlideNumber
                       slideNumber={selectedData?.secondSlide ? selectedData.secondSlide : "-"}
                       emojiCount={

--- a/src/pages/audience-room/ui/AudiencePanel/AudiencePanel.styles.ts
+++ b/src/pages/audience-room/ui/AudiencePanel/AudiencePanel.styles.ts
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { MEDIA } from "@/shared/config/breakpoints";
 
 export const PanelWrapper = styled.div`
   background: #ffffff;
@@ -11,6 +12,16 @@ export const PanelWrapper = styled.div`
   overflow: hidden;
   box-sizing: border-box;
   flex-shrink: 0;
+
+  /* 모바일: 세로 스택 하단에서 남은 높이를 채우는 라이브 채팅 형태 */
+  @media ${MEDIA.mobile} {
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    box-shadow: none;
+    border: none;
+    border-top: 1px solid #eaeaea;
+  }
 `;
 
 export const HeaderBox = styled.div`
@@ -23,6 +34,13 @@ export const HeaderBox = styled.div`
   background: #f9f9f9;
   flex-shrink: 0;
   box-sizing: border-box;
+
+  @media ${MEDIA.mobile} {
+    height: auto;
+    padding: 8px 16px;
+    border-left: none;
+    border-right: none;
+  }
 `;
 
 export const Section = styled.div`
@@ -31,6 +49,10 @@ export const Section = styled.div`
   flex: 1;
   min-height: 0;
   padding: 0.5vw;
+
+  @media ${MEDIA.mobile} {
+    padding: 8px 12px 12px;
+  }
 `;
 
 export const Title = styled.h2`
@@ -53,6 +75,11 @@ export const QuestionList = styled.div`
   display: flex;
   flex-direction: column;
   overflow: hidden;
+
+  @media ${MEDIA.mobile} {
+    padding: 8px;
+    border-radius: 12px;
+  }
 `;
 
 export const QuestionScrollArea = styled.div<{ $isWaiting?: boolean }>`
@@ -117,6 +144,11 @@ export const SlideLabel = styled.button<{ $active?: boolean }>`
   &:hover {
     background: #4a4a4a;
     transform: translateY(-1px);
+  }
+
+  @media ${MEDIA.mobile} {
+    padding: 4px 10px;
+    font-size: 11px;
   }
 `;
 
@@ -186,6 +218,11 @@ export const LikeButton = styled.button<{ $active?: boolean }>`
     outline: 2px solid #303030;
     outline-offset: 2px;
   }
+
+  /* 터치 타깃 확보 */
+  @media ${MEDIA.mobile} {
+    padding: 8px 14px;
+  }
 `;
 
 export const LikeIcon = styled.span`
@@ -209,6 +246,10 @@ export const Scrollbar = styled.div`
   right: 0.42vw;
   top: 5.56vh;
   bottom: 1.85vh;
+
+  @media ${MEDIA.mobile} {
+    display: none;
+  }
 `;
 
 export const WaitingMessage = styled.div`
@@ -279,6 +320,11 @@ export const QuestionInput = styled.textarea<{ $isInputting?: boolean }>`
   text-align: left;
   box-sizing: border-box;
   overflow: hidden;
+
+  /* iOS: 16px 미만 입력창 포커스 시 자동 확대 방지 */
+  @media ${MEDIA.mobile} {
+    font-size: 16px;
+  }
 
   &::placeholder {
     color: #999;

--- a/src/pages/audience-room/ui/AudienceRoomPage.styles.ts
+++ b/src/pages/audience-room/ui/AudienceRoomPage.styles.ts
@@ -13,7 +13,10 @@ export const PageContainer = styled.div`
   }
 `;
 
-export const CenterContainer = styled.div<{ $isFullscreen?: boolean }>`
+export const CenterContainer = styled.div<{
+  $isFullscreen?: boolean;
+  $isPseudoFullscreen?: boolean;
+}>`
   display: flex;
   height: 100%;
   flex-direction: column;
@@ -40,6 +43,18 @@ export const CenterContainer = styled.div<{ $isFullscreen?: boolean }>`
       gap: 0;
       overflow: hidden;
       background: #121212;
+    `}
+
+  /* 아이폰 Safari: Element Fullscreen API 미지원 — fixed 오버레이로 유사 전체화면
+     크기는 inset 으로 잡는다 (100vw 는 레이아웃 뷰포트 초과로 넘칠 수 있음) */
+  ${({ $isPseudoFullscreen }) =>
+    $isPseudoFullscreen &&
+    `
+      position: fixed;
+      inset: 0;
+      width: auto;
+      height: auto;
+      z-index: 1000;
     `}
 
   &:fullscreen {

--- a/src/pages/audience-room/ui/AudienceRoomPage.styles.ts
+++ b/src/pages/audience-room/ui/AudienceRoomPage.styles.ts
@@ -1,10 +1,16 @@
 import styled from "styled-components";
+import { MEDIA } from "@/shared/config/breakpoints";
 
 export const PageContainer = styled.div`
   display: flex;
   height: 100%;
   min-height: 0;
   background-color: #fff;
+
+  /* 모바일: 세로 스택 — 슬라이드 / 리액션 / 실시간 질문 */
+  @media ${MEDIA.mobile} {
+    flex-direction: column;
+  }
 `;
 
 export const CenterContainer = styled.div<{ $isFullscreen?: boolean }>`
@@ -17,11 +23,19 @@ export const CenterContainer = styled.div<{ $isFullscreen?: boolean }>`
   position: relative;
   background: #fff;
 
+  @media ${MEDIA.mobile} {
+    flex: 0 0 auto;
+    height: auto;
+    gap: 0;
+    padding: 0;
+  }
+
   ${({ $isFullscreen }) =>
     $isFullscreen &&
     `
       width: 100vw;
       height: 100vh;
+      height: 100dvh;
       padding: 0;
       gap: 0;
       overflow: hidden;
@@ -31,6 +45,7 @@ export const CenterContainer = styled.div<{ $isFullscreen?: boolean }>`
   &:fullscreen {
     width: 100vw;
     height: 100vh;
+    height: 100dvh;
     padding: 0;
     gap: 0;
     overflow: hidden;
@@ -40,6 +55,7 @@ export const CenterContainer = styled.div<{ $isFullscreen?: boolean }>`
   &:-webkit-full-screen {
     width: 100vw;
     height: 100vh;
+    height: 100dvh;
     padding: 0;
     gap: 0;
     overflow: hidden;
@@ -52,4 +68,36 @@ export const RightPanelContainer = styled.div`
   justify-content: flex-end;
   align-items: flex-start;
   height: 100%;
+
+  /* 모바일: 남은 세로 공간 전체를 실시간 질문 영역으로 */
+  @media ${MEDIA.mobile} {
+    flex: 1;
+    min-height: 0;
+    width: 100%;
+    height: auto;
+    justify-content: stretch;
+    align-items: stretch;
+  }
+`;
+
+/* 모바일에서 이모지 선택 후 첫 스탬프 전까지 노출되는 안내 칩 */
+export const MobileStampHint = styled.div`
+  display: none;
+
+  @media ${MEDIA.mobile} {
+    display: block;
+    position: absolute;
+    left: 50%;
+    bottom: 64px;
+    transform: translateX(-50%);
+    padding: 8px 14px;
+    border-radius: 100px;
+    background: rgba(48, 48, 48, 0.85);
+    color: #fff;
+    font-size: 12px;
+    font-weight: 500;
+    white-space: nowrap;
+    pointer-events: none;
+    z-index: 11;
+  }
 `;

--- a/src/pages/audience-room/ui/AudienceRoomPage.tsx
+++ b/src/pages/audience-room/ui/AudienceRoomPage.tsx
@@ -349,6 +349,7 @@ const AudienceRoomPage = () => {
           fullscreenControlsVisible={!isFullscreen || areFullscreenControlsVisible}
           fullscreenSlideChipVisible={isFullscreen && isFullscreenSlideChipVisible}
           onToggleFullscreen={handleToggleFullscreen}
+          onNavigate={(delta) => handleAudienceSelectSlide(currentSlide + delta)}
           reactionBar={
             quickSettings.sticker ? (
               <EmojiPanel selectedId={selectedEmoji?.id} onSelect={handleSelectEmoji} />

--- a/src/pages/audience-room/ui/AudienceRoomPage.tsx
+++ b/src/pages/audience-room/ui/AudienceRoomPage.tsx
@@ -12,6 +12,7 @@ import {
 } from "./AudienceRoomPage.styles";
 import { useIsMobile } from "@/shared/lib/use-media-query";
 import { useVisualViewportHeight } from "@/shared/lib/use-visual-viewport-height";
+import { useImmersiveMode } from "@/shared/lib/use-immersive-mode";
 import SlideViewer from "./SlideViewerAudience/SlideViewer_audience";
 import { EmojiPanel, useEmojiReactions, useStickerLoader } from "@/entities/reaction";
 import { WebSocketService } from "@/shared/api/websocket";
@@ -33,15 +34,6 @@ import DelayAudience from "./DelayAudience";
 import SessionEndedAudience from "./SessionEndedAudience";
 import { roomIdAtom, deckIdAtom, totalPagesAtom, wsUrlAtom } from "@/entities/room";
 import { quickSettingsAtom, unlockSettingsAtom } from "@/entities/session";
-
-type FullscreenElement = HTMLDivElement & {
-  webkitRequestFullscreen?: () => Promise<void>;
-};
-
-type FullscreenDocument = Document & {
-  webkitFullscreenElement?: Element | null;
-  webkitExitFullscreen?: () => Promise<void>;
-};
 
 const FULLSCREEN_CONTROLS_IDLE_MS = 5000;
 
@@ -67,12 +59,18 @@ const AudienceRoomPage = () => {
   const [selectedEmoji, setSelectedEmoji] = useState<any>(null);
   const [showStamps, setShowStamps] = useState(true);
   const [hasPlacedStamp, setHasPlacedStamp] = useState(false);
-  const [isFullscreen, setIsFullscreen] = useState(false);
   const [areFullscreenControlsVisible, setAreFullscreenControlsVisible] = useState(false);
   const [isFullscreenSlideChipVisible, setIsFullscreenSlideChipVisible] = useState(false);
   const [showAudienceJoinWarning, setShowAudienceJoinWarning] = useState(false);
   const lastPresenterPageRef = useRef(0);
-  const centerContainerRef = useRef<FullscreenElement | null>(null);
+  const centerContainerRef = useRef<HTMLDivElement | null>(null);
+
+  // * 네이티브 전체화면(데스크톱/안드로이드) 또는 pseudo-fullscreen(아이폰) 통합 토글
+  const {
+    isImmersive: isFullscreen,
+    isPseudoFullscreen,
+    toggleImmersive: handleToggleFullscreen,
+  } = useImmersiveMode(centerContainerRef);
   const fullscreenControlsTimerRef = useRef<number | null>(null);
   const fullscreenSlideChipTimerRef = useRef<number | null>(null);
   const shouldConsumeFullscreenClickRef = useRef(false);
@@ -239,29 +237,14 @@ const AudienceRoomPage = () => {
     scheduleFullscreenControlsHide();
   }, [isFullscreen, scheduleFullscreenControlsHide]);
 
+  // * 몰입 모드 진입/이탈 시 컨트롤 표시 상태 초기화 (네이티브/pseudo 공통)
   useEffect(() => {
-    const handleFullscreenChange = () => {
-      const fullscreenDocument = document as FullscreenDocument;
-      const isCurrentContainerFullscreen =
-        document.fullscreenElement === centerContainerRef.current ||
-        fullscreenDocument.webkitFullscreenElement === centerContainerRef.current;
-
-      setIsFullscreen(isCurrentContainerFullscreen);
-      setAreFullscreenControlsVisible(false);
-      setIsFullscreenSlideChipVisible(false);
-      clearFullscreenControlsTimer();
-      clearFullscreenSlideChipTimer();
-      shouldConsumeFullscreenClickRef.current = false;
-    };
-
-    document.addEventListener("fullscreenchange", handleFullscreenChange);
-    document.addEventListener("webkitfullscreenchange", handleFullscreenChange);
-
-    return () => {
-      document.removeEventListener("fullscreenchange", handleFullscreenChange);
-      document.removeEventListener("webkitfullscreenchange", handleFullscreenChange);
-    };
-  }, [clearFullscreenControlsTimer, clearFullscreenSlideChipTimer]);
+    setAreFullscreenControlsVisible(false);
+    setIsFullscreenSlideChipVisible(false);
+    clearFullscreenControlsTimer();
+    clearFullscreenSlideChipTimer();
+    shouldConsumeFullscreenClickRef.current = false;
+  }, [isFullscreen, clearFullscreenControlsTimer, clearFullscreenSlideChipTimer]);
 
   useEffect(() => clearFullscreenControlsTimer, [clearFullscreenControlsTimer]);
   useEffect(() => clearFullscreenSlideChipTimer, [clearFullscreenSlideChipTimer]);
@@ -293,36 +276,6 @@ const AudienceRoomPage = () => {
     shouldConsumeFullscreenClickRef.current = false;
     event.preventDefault();
     event.stopPropagation();
-  };
-
-  const handleToggleFullscreen = async () => {
-    const fullscreenDocument = document as FullscreenDocument;
-    const activeFullscreenElement =
-      document.fullscreenElement || fullscreenDocument.webkitFullscreenElement;
-
-    if (activeFullscreenElement) {
-      if (document.exitFullscreen) {
-        await document.exitFullscreen();
-        return;
-      }
-
-      if (fullscreenDocument.webkitExitFullscreen) {
-        await fullscreenDocument.webkitExitFullscreen();
-      }
-      return;
-    }
-
-    const fullscreenElement = centerContainerRef.current;
-    if (!fullscreenElement) return;
-
-    if (fullscreenElement.requestFullscreen) {
-      await fullscreenElement.requestFullscreen();
-      return;
-    }
-
-    if (fullscreenElement.webkitRequestFullscreen) {
-      await fullscreenElement.webkitRequestFullscreen();
-    }
   };
 
   // Audience opened the session URL after it already ended: same layout as the
@@ -374,6 +327,7 @@ const AudienceRoomPage = () => {
       <CenterContainer
         ref={centerContainerRef}
         $isFullscreen={isFullscreen}
+        $isPseudoFullscreen={isPseudoFullscreen}
         onPointerMove={handleFullscreenPointerMove}
         onPointerDownCapture={handleFullscreenPointerDownCapture}
         onClickCapture={handleFullscreenClickCapture}

--- a/src/pages/audience-room/ui/AudienceRoomPage.tsx
+++ b/src/pages/audience-room/ui/AudienceRoomPage.tsx
@@ -4,7 +4,14 @@ import { useParams } from "react-router";
 import { useAtomValue } from "jotai";
 import AudiencePanel from "./AudiencePanel";
 import { SlidesSidebar } from "@/widgets/slides-sidebar";
-import { PageContainer, CenterContainer, RightPanelContainer } from "./AudienceRoomPage.styles";
+import {
+  PageContainer,
+  CenterContainer,
+  RightPanelContainer,
+  MobileStampHint,
+} from "./AudienceRoomPage.styles";
+import { useIsMobile } from "@/shared/lib/use-media-query";
+import { useVisualViewportHeight } from "@/shared/lib/use-visual-viewport-height";
 import SlideViewer from "./SlideViewerAudience/SlideViewer_audience";
 import { EmojiPanel, useEmojiReactions, useStickerLoader } from "@/entities/reaction";
 import { WebSocketService } from "@/shared/api/websocket";
@@ -51,9 +58,15 @@ const AudienceRoomPage = () => {
   const quickSettings = useAtomValue(quickSettingsAtom);
   const unlockSettings = useAtomValue(unlockSettingsAtom);
 
+  const isMobile = useIsMobile();
+
+  // * 모바일 키보드가 열릴 때 질문 입력창이 가려지지 않도록 앱 높이를 동기화
+  useVisualViewportHeight(isMobile);
+
   // Local UI state
   const [selectedEmoji, setSelectedEmoji] = useState<any>(null);
   const [showStamps, setShowStamps] = useState(true);
+  const [hasPlacedStamp, setHasPlacedStamp] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [areFullscreenControlsVisible, setAreFullscreenControlsVisible] = useState(false);
   const [isFullscreenSlideChipVisible, setIsFullscreenSlideChipVisible] = useState(false);
@@ -337,17 +350,27 @@ const AudienceRoomPage = () => {
     );
   }
 
+  const handlePlaceStampWithHint = (coords: { xPct: number; yPct: number }) => {
+    if (!hasPlacedStamp) setHasPlacedStamp(true);
+    handlePlaceStamp(coords);
+  };
+
+  const showMobileStampHint =
+    isMobile && !isFullscreen && quickSettings.sticker && Boolean(selectedEmoji) && !hasPlacedStamp;
+
   return (
     <PageContainer>
-      <SlidesSidebar
-        slides={slides}
-        currentSlide={currentSlide}
-        setCurrentSlide={handleAudienceSelectSlide}
-        isWaiting={showSlidesPlaceholder}
-        placeholderCount={totalPages || 10}
-        maxRevealedPage={unlockSettings.maxRevealedPage}
-        revealAllSlides={unlockSettings.revealAllSlides}
-      />
+      {!isMobile && (
+        <SlidesSidebar
+          slides={slides}
+          currentSlide={currentSlide}
+          setCurrentSlide={handleAudienceSelectSlide}
+          isWaiting={showSlidesPlaceholder}
+          placeholderCount={totalPages || 10}
+          maxRevealedPage={unlockSettings.maxRevealedPage}
+          revealAllSlides={unlockSettings.revealAllSlides}
+        />
+      )}
       <CenterContainer
         ref={centerContainerRef}
         $isFullscreen={isFullscreen}
@@ -360,7 +383,7 @@ const AudienceRoomPage = () => {
           slides={slides}
           currentSlide={currentSlide}
           stamps={stampsBySlide[String(currentSlide)] || []}
-          onPlace={handlePlaceStamp}
+          onPlace={handlePlaceStampWithHint}
           followPresenter={followPresenter}
           onToggleFollow={handleToggleFollowPresenter}
           showStamps={showStamps}
@@ -409,6 +432,9 @@ const AudienceRoomPage = () => {
         {/* 전체화면에서는 슬라이드 위 오버레이로 리액션 바를 띄운다 (일반 화면은 SlideViewer 내부 컨트롤 줄에 배치) */}
         {quickSettings.sticker && isFullscreen && areFullscreenControlsVisible && (
           <EmojiPanel selectedId={selectedEmoji?.id} onSelect={handleSelectEmoji} />
+        )}
+        {showMobileStampHint && (
+          <MobileStampHint>슬라이드를 탭해 스티커를 남겨보세요</MobileStampHint>
         )}
       </CenterContainer>
       <RightPanelContainer>

--- a/src/pages/audience-room/ui/DelayAudience.styles.ts
+++ b/src/pages/audience-room/ui/DelayAudience.styles.ts
@@ -28,4 +28,7 @@ export const WaitingMessage = styled.p`
   font-weight: 400;
   color: #666;
   margin: 0;
+  padding: 0 24px;
+  text-align: center;
+  word-break: keep-all;
 `;

--- a/src/pages/audience-room/ui/SlideViewerAudience/SlideViewer_audience.styles.ts
+++ b/src/pages/audience-room/ui/SlideViewerAudience/SlideViewer_audience.styles.ts
@@ -218,6 +218,17 @@ export const SlideBox = styled.div<{ focusHighlight?: boolean; $isFullscreen?: b
     `}
 `;
 
+/* 리액션 스탬프 — 슬라이드 폭 대비 상대 크기 (broadcast 3.4cqw 와 동일 비율) */
+export const StampImage = styled.img`
+  position: absolute;
+  transform: translate(-50%, -50%);
+  width: 3.4%;
+  height: auto;
+  aspect-ratio: 1;
+  object-fit: contain;
+  pointer-events: none;
+`;
+
 export const NavButton = styled.button`
   padding: 0.8vh 0.8vw;
   border: 0.05vw solid #ddd;
@@ -235,7 +246,7 @@ export const ToggleText = styled.span`
   letter-spacing: -0.021vw;
 
   @media ${MEDIA.mobile} {
-    font-size: 13px;
+    font-size: 12px;
     line-height: 1.4;
     letter-spacing: -0.2px;
     white-space: nowrap;
@@ -265,6 +276,19 @@ export const ReactionButton = styled.button<{ $isFullscreen?: boolean }>`
     aspect-ratio: 1;
     object-fit: contain;
   }
+
+  /* 모바일(비전체화면): 상단 바에 맞는 축소 크기 */
+  ${({ $isFullscreen }) =>
+    !$isFullscreen &&
+    css`
+      @media ${MEDIA.mobile} {
+        padding: 9px;
+
+        img {
+          width: 22px;
+        }
+      }
+    `}
 `;
 
 export const FullscreenButton = styled.button<{
@@ -330,6 +354,19 @@ export const FullscreenButton = styled.button<{
     css`
       > img {
         width: clamp(30px, 1.9vw, 36px);
+      }
+    `}
+
+  /* 모바일(비전체화면): 상단/하단 컨트롤 줄에 맞는 축소 크기 */
+  ${({ $isFullscreen }) =>
+    !$isFullscreen &&
+    css`
+      @media ${MEDIA.mobile} {
+        padding: 9px;
+
+        > img {
+          width: 22px;
+        }
       }
     `}
 `;
@@ -506,14 +543,47 @@ export const WaitingText = styled.p`
   }
 `;
 
-/* 모바일 전용: 상단 바 가운데 현재 슬라이드 표시 칩 */
+/* 모바일 전용: 상단 바 가운데 ‹ n / N › 페이저 */
+export const MobileNavGroup = styled.div`
+  display: none;
+
+  @media ${MEDIA.mobile} {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+  }
+`;
+
+export const MobileNavButton = styled.button`
+  display: none;
+
+  @media ${MEDIA.mobile} {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: #5c5c5c;
+    font-size: 20px;
+    line-height: 1;
+    cursor: pointer;
+
+    &:disabled {
+      color: #c9c9c9;
+    }
+  }
+`;
+
 export const MobileSlideChip = styled.span`
   display: none;
 
   @media ${MEDIA.mobile} {
     display: inline-flex;
     align-items: center;
-    padding: 4px 12px;
+    padding: 4px 10px;
     border: 1px solid #eaeaea;
     border-radius: 100px;
     background: #fafafa;

--- a/src/pages/audience-room/ui/SlideViewerAudience/SlideViewer_audience.styles.ts
+++ b/src/pages/audience-room/ui/SlideViewerAudience/SlideViewer_audience.styles.ts
@@ -14,15 +14,20 @@ export const Main = styled.div<{ $isFullscreen?: boolean }>`
   background: #fff;
   position: relative;
 
-  @media ${MEDIA.mobile} {
-    padding: 8px 12px;
-    gap: 8px;
-  }
+  /* 전체화면 스타일과의 병합 충돌 방지를 위해 비전체화면일 때만 적용 */
+  ${({ $isFullscreen }) =>
+    !$isFullscreen &&
+    css`
+      @media ${MEDIA.mobile} {
+        padding: 8px 12px;
+        gap: 8px;
+      }
+    `}
 
   ${({ $isFullscreen }) =>
     $isFullscreen &&
     `
-      width: 100vw;
+      width: 100%;
       height: 100vh;
       height: 100dvh;
       padding: clamp(24px, 3vh, 32px) 0 clamp(72px, 8vh, 88px);
@@ -144,6 +149,7 @@ export const ReactionSlot = styled.div`
     position: relative;
     top: auto;
     left: auto;
+    right: auto;
     transform: none;
     margin: 0;
     width: clamp(320px, 34vw, 480px);
@@ -189,10 +195,14 @@ export const SlideBox = styled.div<{ focusHighlight?: boolean; $isFullscreen?: b
   touch-action: manipulation;
   -webkit-tap-highlight-color: transparent;
 
-  @media ${MEDIA.mobile} {
-    border-radius: 8px;
-    border: 1px solid #ddd;
-  }
+  ${({ $isFullscreen }) =>
+    !$isFullscreen &&
+    css`
+      @media ${MEDIA.mobile} {
+        border-radius: 8px;
+        border: 1px solid #ddd;
+      }
+    `}
 
   ${({ focusHighlight }) => (focusHighlight ? HighlightedSlideStyles : css``)}
 
@@ -376,6 +386,12 @@ export const SlideNumberChip = styled.div<{ $visible?: boolean }>`
   opacity: ${({ $visible }) => ($visible ? 1 : 0)};
   pointer-events: none;
   transition: opacity 0.2s ease;
+
+  /* 모바일 전체화면: 하단 이모지 바와 겹치지 않게 그 위로 배치 */
+  @media ${MEDIA.mobile} {
+    left: 12px;
+    bottom: 116px;
+  }
 `;
 
 export const TooltipWrapper = styled.div`

--- a/src/pages/audience-room/ui/SlideViewerAudience/SlideViewer_audience.styles.ts
+++ b/src/pages/audience-room/ui/SlideViewerAudience/SlideViewer_audience.styles.ts
@@ -1,5 +1,6 @@
 import styled, { css } from "styled-components";
 import { ToggleInput, HighlightedSlideStyles } from "@/widgets/presentation-layout";
+import { MEDIA } from "@/shared/config/breakpoints";
 
 /* 전체 컨테이너 */
 export const Main = styled.div<{ $isFullscreen?: boolean }>`
@@ -13,11 +14,17 @@ export const Main = styled.div<{ $isFullscreen?: boolean }>`
   background: #fff;
   position: relative;
 
+  @media ${MEDIA.mobile} {
+    padding: 8px 12px;
+    gap: 8px;
+  }
+
   ${({ $isFullscreen }) =>
     $isFullscreen &&
     `
       width: 100vw;
       height: 100vh;
+      height: 100dvh;
       padding: clamp(24px, 3vh, 32px) 0 clamp(72px, 8vh, 88px);
       gap: 0;
       justify-content: center;
@@ -32,6 +39,16 @@ export const RightContainer = styled.div`
   gap: 0.52vw;
   width: 9.38vw;
   height: 2.78vh;
+
+  @media ${MEDIA.mobile} {
+    width: auto;
+    height: auto;
+    gap: 6px;
+
+    img {
+      display: none;
+    }
+  }
 `;
 export const ToggleContainer = styled.div<{ $isFullscreen?: boolean }>`
   display: flex;
@@ -107,6 +124,11 @@ export const ControlsRow = styled.div`
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
   width: 100%;
+
+  @media ${MEDIA.mobile} {
+    display: flex;
+    gap: 8px;
+  }
 `;
 
 /* 리액션 스티커 바를 흐름 배치로 전환해 가운데 칸에 정렬 */
@@ -127,6 +149,15 @@ export const ReactionSlot = styled.div`
     width: clamp(320px, 34vw, 480px);
     max-width: 100%;
   }
+
+  @media ${MEDIA.mobile} {
+    flex: 1;
+    min-width: 0;
+
+    > div {
+      width: 100%;
+    }
+  }
 `;
 
 /* 오른쪽 끝 칸: 전체화면 버튼 */
@@ -135,6 +166,10 @@ export const ControlsEnd = styled.div`
   display: flex;
   justify-content: flex-end;
   align-items: center;
+
+  @media ${MEDIA.mobile} {
+    flex: none;
+  }
 `;
 
 /* 슬라이드 본문 */
@@ -150,12 +185,22 @@ export const SlideBox = styled.div<{ focusHighlight?: boolean; $isFullscreen?: b
   justify-content: center;
   border-radius: 0.6vw;
   border: 0.05vw solid #ddd;
+  /* 더블탭 확대·클릭 지연 제거 — 연속 스탬프 터치 반응성 확보 */
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+
+  @media ${MEDIA.mobile} {
+    border-radius: 8px;
+    border: 1px solid #ddd;
+  }
+
   ${({ focusHighlight }) => (focusHighlight ? HighlightedSlideStyles : css``)}
 
   ${({ $isFullscreen }) =>
     $isFullscreen &&
     `
       width: min(100%, calc((100vh - clamp(112px, 12vh, 140px)) * 16 / 9));
+      width: min(100%, calc((100dvh - clamp(112px, 12vh, 140px)) * 16 / 9));
       aspect-ratio: 16 / 9;
       border: 1px solid #eaeaea;
       border-radius: 10px;
@@ -178,6 +223,13 @@ export const ToggleText = styled.span`
   font-weight: 600;
   line-height: 2.22vh;
   letter-spacing: -0.021vw;
+
+  @media ${MEDIA.mobile} {
+    font-size: 13px;
+    line-height: 1.4;
+    letter-spacing: -0.2px;
+    white-space: nowrap;
+  }
 `;
 
 export const ReactionButton = styled.button<{ $isFullscreen?: boolean }>`
@@ -347,6 +399,11 @@ export const Tooltip = styled.div`
   opacity: 0;
   transition: opacity 0.15s ease;
 
+  /* 터치 기기: hover 툴팁 비활성 */
+  @media ${MEDIA.touch} {
+    display: none;
+  }
+
   color: rgb(0, 0, 0);
   font-size: 0.63vw;
   font-weight: 400;
@@ -410,6 +467,10 @@ export const WaitingImage = styled.img`
   width: clamp(6.25vw, 12vw, 9.38vw);
   height: auto;
   object-fit: contain;
+
+  @media ${MEDIA.mobile} {
+    width: 28vw;
+  }
 `;
 
 export const WaitingText = styled.p`
@@ -421,4 +482,28 @@ export const WaitingText = styled.p`
   line-height: 2.04vh;
   letter-spacing: -0.02vw;
   white-space: pre-line;
+
+  @media ${MEDIA.mobile} {
+    font-size: 14px;
+    line-height: 1.5;
+    letter-spacing: -0.3px;
+  }
+`;
+
+/* 모바일 전용: 상단 바 가운데 현재 슬라이드 표시 칩 */
+export const MobileSlideChip = styled.span`
+  display: none;
+
+  @media ${MEDIA.mobile} {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 12px;
+    border: 1px solid #eaeaea;
+    border-radius: 100px;
+    background: #fafafa;
+    color: #303030;
+    font-size: 12px;
+    font-weight: 600;
+    white-space: nowrap;
+  }
 `;

--- a/src/pages/audience-room/ui/SlideViewerAudience/SlideViewer_audience.tsx
+++ b/src/pages/audience-room/ui/SlideViewerAudience/SlideViewer_audience.tsx
@@ -1,5 +1,11 @@
-import React, { useRef } from "react";
-import type { MouseEvent, ChangeEvent, TouchEvent } from "react";
+import React, { useRef, useState } from "react";
+import type { MouseEvent, ChangeEvent, TouchEvent, SyntheticEvent } from "react";
+import {
+  slideContentFractions,
+  stampBoxStyle,
+  boxPointToContentPct,
+  imageNaturalRatio,
+} from "@/shared/lib/slide-geometry";
 import {
   Main,
   SlideBox,
@@ -90,9 +96,17 @@ const SlideViewer = ({
   const boxRef = useRef<HTMLDivElement | null>(null);
   const touchStartRef = useRef<{ x: number; y: number } | null>(null);
   const suppressClickAfterSwipeRef = useRef(false);
+  const [slideNaturalRatio, setSlideNaturalRatio] = useState<number | null>(null);
   const hasSlides = Array.isArray(slides) && slides.length > 0;
   const safeSlideIndex = hasSlides ? Math.min(Math.max(currentSlide, 0), slides.length - 1) : 0;
   const currentSlideSrc = hasSlides ? slides[safeSlideIndex] : null;
+
+  // 레터박스를 제외한 실제 슬라이드 콘텐츠 영역 — 스탬프 좌표의 기준
+  const contentFractions = slideContentFractions(slideNaturalRatio);
+
+  const handleSlideImageLoad = (e: SyntheticEvent<HTMLImageElement>) => {
+    setSlideNaturalRatio(imageNaturalRatio(e.currentTarget));
+  };
 
   const handleClick = (e: MouseEvent<HTMLDivElement>) => {
     // 스와이프 직후 발생하는 click 은 스탬프로 처리하지 않는다
@@ -102,9 +116,14 @@ const SlideViewer = ({
     }
     if (isWaiting || !onPlace || !boxRef.current) return;
     const rect = boxRef.current.getBoundingClientRect();
-    const xPct = ((e.clientX - rect.left) / rect.width) * 100;
-    const yPct = ((e.clientY - rect.top) / rect.height) * 100;
-    onPlace({ xPct, yPct });
+    const point = boxPointToContentPct(
+      (e.clientX - rect.left) / rect.width,
+      (e.clientY - rect.top) / rect.height,
+      contentFractions
+    );
+    // 레터박스(여백) 영역 탭은 무시
+    if (!point) return;
+    onPlace(point);
   };
 
   const handleTouchStart = (e: TouchEvent<HTMLDivElement>) => {
@@ -179,6 +198,7 @@ const SlideViewer = ({
           <img
             src={currentSlideSrc}
             alt={`슬라이드 ${safeSlideIndex + 1}`}
+            onLoad={handleSlideImageLoad}
             style={{
               width: "100%",
               height: "100%",
@@ -198,10 +218,7 @@ const SlideViewer = ({
             key={stamp.id || `${stamp.xPct}-${stamp.yPct}-${idx}`}
             src={stamp.src}
             alt="stamp"
-            style={{
-              top: `${stamp.yPct}%`,
-              left: `${stamp.xPct}%`,
-            }}
+            style={stampBoxStyle(stamp.xPct, stamp.yPct, contentFractions)}
           />
         ))}
     </SlideBox>

--- a/src/pages/audience-room/ui/SlideViewerAudience/SlideViewer_audience.tsx
+++ b/src/pages/audience-room/ui/SlideViewerAudience/SlideViewer_audience.tsx
@@ -5,7 +5,9 @@ import {
   stampBoxStyle,
   boxPointToContentPct,
   imageNaturalRatio,
+  SLIDE_BOX_ASPECT,
 } from "@/shared/lib/slide-geometry";
+import { useElementAspectRatio } from "@/shared/lib/use-element-aspect-ratio";
 import {
   Main,
   SlideBox,
@@ -103,7 +105,9 @@ const SlideViewer = ({
   const currentSlideSrc = hasSlides ? slides[safeSlideIndex] : null;
 
   // 레터박스를 제외한 실제 슬라이드 콘텐츠 영역 — 스탬프 좌표의 기준
-  const contentFractions = slideContentFractions(slideNaturalRatio);
+  // 박스는 flex 축소로 16:9 에서 벗어날 수 있으므로 실측 비율을 쓴다
+  const boxRatio = useElementAspectRatio(boxRef);
+  const contentFractions = slideContentFractions(slideNaturalRatio, boxRatio ?? SLIDE_BOX_ASPECT);
 
   // 캐시된 이미지는 onLoad 를 놓칠 수 있어 ref 시점에 complete 여부도 확인
   const attachSlideImage = (img: HTMLImageElement | null) => {
@@ -131,10 +135,11 @@ const SlideViewer = ({
     if (!liveRatio) return;
 
     const rect = boxRef.current.getBoundingClientRect();
+    if (!rect.width || !rect.height) return;
     const point = boxPointToContentPct(
       (e.clientX - rect.left) / rect.width,
       (e.clientY - rect.top) / rect.height,
-      slideContentFractions(liveRatio)
+      slideContentFractions(liveRatio, rect.width / rect.height)
     );
     // 레터박스(여백) 영역 탭은 무시
     if (!point) return;

--- a/src/pages/audience-room/ui/SlideViewerAudience/SlideViewer_audience.tsx
+++ b/src/pages/audience-room/ui/SlideViewerAudience/SlideViewer_audience.tsx
@@ -94,6 +94,7 @@ const SlideViewer = ({
   onNavigate,
 }: SlideViewerProps) => {
   const boxRef = useRef<HTMLDivElement | null>(null);
+  const slideImageRef = useRef<HTMLImageElement | null>(null);
   const touchStartRef = useRef<{ x: number; y: number } | null>(null);
   const suppressClickAfterSwipeRef = useRef(false);
   const [slideNaturalRatio, setSlideNaturalRatio] = useState<number | null>(null);
@@ -103,6 +104,14 @@ const SlideViewer = ({
 
   // 레터박스를 제외한 실제 슬라이드 콘텐츠 영역 — 스탬프 좌표의 기준
   const contentFractions = slideContentFractions(slideNaturalRatio);
+
+  // 캐시된 이미지는 onLoad 를 놓칠 수 있어 ref 시점에 complete 여부도 확인
+  const attachSlideImage = (img: HTMLImageElement | null) => {
+    slideImageRef.current = img;
+    if (img && img.complete) {
+      setSlideNaturalRatio(imageNaturalRatio(img));
+    }
+  };
 
   const handleSlideImageLoad = (e: SyntheticEvent<HTMLImageElement>) => {
     setSlideNaturalRatio(imageNaturalRatio(e.currentTarget));
@@ -115,11 +124,17 @@ const SlideViewer = ({
       return;
     }
     if (isWaiting || !onPlace || !boxRef.current) return;
+
+    // 상태가 아직 갱신되지 않았어도 클릭 시점의 실제 이미지에서 비율을 직접 읽는다
+    // (로딩 지연/슬라이드 전환 중 잘못된 좌표계로 전송되는 것을 방지)
+    const liveRatio = slideImageRef.current ? imageNaturalRatio(slideImageRef.current) : null;
+    if (!liveRatio) return;
+
     const rect = boxRef.current.getBoundingClientRect();
     const point = boxPointToContentPct(
       (e.clientX - rect.left) / rect.width,
       (e.clientY - rect.top) / rect.height,
-      contentFractions
+      slideContentFractions(liveRatio)
     );
     // 레터박스(여백) 영역 탭은 무시
     if (!point) return;
@@ -196,6 +211,8 @@ const SlideViewer = ({
       ) : (
         currentSlideSrc && (
           <img
+            key={currentSlideSrc}
+            ref={attachSlideImage}
             src={currentSlideSrc}
             alt={`슬라이드 ${safeSlideIndex + 1}`}
             onLoad={handleSlideImageLoad}

--- a/src/pages/audience-room/ui/SlideViewerAudience/SlideViewer_audience.tsx
+++ b/src/pages/audience-room/ui/SlideViewerAudience/SlideViewer_audience.tsx
@@ -23,6 +23,7 @@ import {
   FullscreenButton,
   FullscreenExitIcon,
   SlideNumberChip,
+  MobileSlideChip,
 } from "./SlideViewer_audience.styles";
 import TipIcon from "@/shared/assets/images/tooltip.png";
 import fullscreenIcon from "@/shared/assets/icons/fullscreen.svg";
@@ -207,6 +208,12 @@ const SlideViewer = ({
             </RightContainer>
           </FollowTooltipArea>
         </ToggleContainer>
+
+        {!isWaiting && !isFullscreen && hasSlides && (
+          <MobileSlideChip>
+            슬라이드 {safeSlideIndex + 1} / {slides.length}
+          </MobileSlideChip>
+        )}
 
         {!isWaiting && (
           <TooltipHoverArea>

--- a/src/pages/audience-room/ui/SlideViewerAudience/SlideViewer_audience.tsx
+++ b/src/pages/audience-room/ui/SlideViewerAudience/SlideViewer_audience.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from "react";
-import type { MouseEvent, ChangeEvent } from "react";
+import type { MouseEvent, ChangeEvent, TouchEvent } from "react";
 import {
   Main,
   SlideBox,
@@ -24,6 +24,9 @@ import {
   FullscreenExitIcon,
   SlideNumberChip,
   MobileSlideChip,
+  MobileNavGroup,
+  MobileNavButton,
+  StampImage,
 } from "./SlideViewer_audience.styles";
 import TipIcon from "@/shared/assets/images/tooltip.png";
 import fullscreenIcon from "@/shared/assets/icons/fullscreen.svg";
@@ -58,7 +61,11 @@ interface SlideViewerProps {
   onToggleFullscreen?: () => void | Promise<void>;
   /** 슬라이드 아래 컨트롤 줄 가운데에 배치할 리액션 스티커 바 (전체화면 아닐 때만) */
   reactionBar?: React.ReactNode;
+  /** 모바일 스와이프/페이저 내비게이션 — delta 는 ±1 (잠금/범위 처리는 호출부 책임) */
+  onNavigate?: (delta: 1 | -1) => void;
 }
+
+const SWIPE_MIN_DISTANCE_PX = 48;
 
 const SlideViewer = ({
   slides = [],
@@ -78,18 +85,55 @@ const SlideViewer = ({
   fullscreenSlideChipVisible = false,
   onToggleFullscreen,
   reactionBar = null,
+  onNavigate,
 }: SlideViewerProps) => {
   const boxRef = useRef<HTMLDivElement | null>(null);
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null);
+  const suppressClickAfterSwipeRef = useRef(false);
   const hasSlides = Array.isArray(slides) && slides.length > 0;
   const safeSlideIndex = hasSlides ? Math.min(Math.max(currentSlide, 0), slides.length - 1) : 0;
   const currentSlideSrc = hasSlides ? slides[safeSlideIndex] : null;
 
   const handleClick = (e: MouseEvent<HTMLDivElement>) => {
+    // 스와이프 직후 발생하는 click 은 스탬프로 처리하지 않는다
+    if (suppressClickAfterSwipeRef.current) {
+      suppressClickAfterSwipeRef.current = false;
+      return;
+    }
     if (isWaiting || !onPlace || !boxRef.current) return;
     const rect = boxRef.current.getBoundingClientRect();
     const xPct = ((e.clientX - rect.left) / rect.width) * 100;
     const yPct = ((e.clientY - rect.top) / rect.height) * 100;
     onPlace({ xPct, yPct });
+  };
+
+  const handleTouchStart = (e: TouchEvent<HTMLDivElement>) => {
+    // 스와이프 뒤 click 이 발생하지 않는 경우를 대비해 새 제스처 시작 시 플래그 해제
+    suppressClickAfterSwipeRef.current = false;
+    if (e.touches.length !== 1) {
+      touchStartRef.current = null;
+      return;
+    }
+    touchStartRef.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+  };
+
+  const handleTouchEnd = (e: TouchEvent<HTMLDivElement>) => {
+    const start = touchStartRef.current;
+    touchStartRef.current = null;
+    if (!start || isWaiting || typeof onNavigate !== "function") return;
+
+    const touch = e.changedTouches[0];
+    if (!touch) return;
+    const deltaX = touch.clientX - start.x;
+    const deltaY = touch.clientY - start.y;
+
+    // 수평 이동이 충분히 크고 수직 성분보다 명확히 우세할 때만 스와이프로 판정
+    if (Math.abs(deltaX) < SWIPE_MIN_DISTANCE_PX || Math.abs(deltaX) < Math.abs(deltaY) * 1.5) {
+      return;
+    }
+
+    suppressClickAfterSwipeRef.current = true;
+    onNavigate(deltaX < 0 ? 1 : -1);
   };
 
   const handleToggleFollowChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -116,6 +160,8 @@ const SlideViewer = ({
     <SlideBox
       ref={boxRef}
       onClick={handleClick}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
       focusHighlight={focusHighlight}
       $isFullscreen={isFullscreen}
       data-testid="audience-slide-surface"
@@ -148,18 +194,13 @@ const SlideViewer = ({
       {!isWaiting &&
         showStamps &&
         stamps.map((stamp: StampItem, idx: number) => (
-          <img
+          <StampImage
             key={stamp.id || `${stamp.xPct}-${stamp.yPct}-${idx}`}
             src={stamp.src}
             alt="stamp"
             style={{
-              position: "absolute",
               top: `${stamp.yPct}%`,
               left: `${stamp.xPct}%`,
-              transform: "translate(-50%, -50%)",
-              width: 25,
-              height: 25,
-              pointerEvents: "none",
             }}
           />
         ))}
@@ -210,9 +251,27 @@ const SlideViewer = ({
         </ToggleContainer>
 
         {!isWaiting && !isFullscreen && hasSlides && (
-          <MobileSlideChip>
-            슬라이드 {safeSlideIndex + 1} / {slides.length}
-          </MobileSlideChip>
+          <MobileNavGroup>
+            <MobileNavButton
+              type="button"
+              aria-label="이전 슬라이드"
+              disabled={safeSlideIndex === 0}
+              onClick={() => onNavigate?.(-1)}
+            >
+              ‹
+            </MobileNavButton>
+            <MobileSlideChip>
+              {safeSlideIndex + 1} / {slides.length}
+            </MobileSlideChip>
+            <MobileNavButton
+              type="button"
+              aria-label="다음 슬라이드"
+              disabled={safeSlideIndex >= slides.length - 1}
+              onClick={() => onNavigate?.(1)}
+            >
+              ›
+            </MobileNavButton>
+          </MobileNavGroup>
         )}
 
         {!isWaiting && (

--- a/src/pages/broadcast-screen/ui/BroadcastScreenPage.tsx
+++ b/src/pages/broadcast-screen/ui/BroadcastScreenPage.tsx
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { MouseEvent } from "react";
+import type { MouseEvent, SyntheticEvent } from "react";
+import {
+  slideContentFractions,
+  stampBoxStyle,
+  imageNaturalRatio,
+} from "@/shared/lib/slide-geometry";
 import { useParams } from "react-router";
 import {
   getBroadcastChannelName,
@@ -61,6 +66,7 @@ const BroadcastScreenPage = () => {
   const [slideIndex, setSlideIndex] = useState(0);
   const [stamps, setStamps] = useState<BroadcastStamp[]>([]);
   const [showStamps, setShowStamps] = useState(false);
+  const [slideNaturalRatio, setSlideNaturalRatio] = useState<number | null>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [controlsVisible, setControlsVisible] = useState(false);
   const channelRef = useRef<BroadcastChannel | null>(null);
@@ -245,14 +251,25 @@ const BroadcastScreenPage = () => {
     >
       {currentSrc ? (
         <Stage>
-          <SlideImage src={currentSrc} alt={`슬라이드 ${slideIndex + 1}`} draggable={false} />
+          <SlideImage
+            src={currentSrc}
+            alt={`슬라이드 ${slideIndex + 1}`}
+            draggable={false}
+            onLoad={(e: SyntheticEvent<HTMLImageElement>) =>
+              setSlideNaturalRatio(imageNaturalRatio(e.currentTarget))
+            }
+          />
           {showStamps &&
             stamps.map((stamp, index) => (
               <BroadcastStampImage
                 key={stamp.id || `${stamp.xPct}-${stamp.yPct}-${index}`}
                 src={stamp.src}
                 alt="reaction"
-                style={{ top: `${stamp.yPct}%`, left: `${stamp.xPct}%` }}
+                style={stampBoxStyle(
+                  stamp.xPct,
+                  stamp.yPct,
+                  slideContentFractions(slideNaturalRatio)
+                )}
                 draggable={false}
               />
             ))}

--- a/src/pages/broadcast-screen/ui/BroadcastScreenPage.tsx
+++ b/src/pages/broadcast-screen/ui/BroadcastScreenPage.tsx
@@ -4,7 +4,9 @@ import {
   slideContentFractions,
   stampBoxStyle,
   imageNaturalRatio,
+  SLIDE_BOX_ASPECT,
 } from "@/shared/lib/slide-geometry";
+import { useElementAspectRatio } from "@/shared/lib/use-element-aspect-ratio";
 import { useParams } from "react-router";
 import {
   getBroadcastChannelName,
@@ -67,6 +69,8 @@ const BroadcastScreenPage = () => {
   const [stamps, setStamps] = useState<BroadcastStamp[]>([]);
   const [showStamps, setShowStamps] = useState(false);
   const [slideNaturalRatio, setSlideNaturalRatio] = useState<number | null>(null);
+  const stageRef = useRef<HTMLDivElement | null>(null);
+  const stageRatio = useElementAspectRatio(stageRef);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [controlsVisible, setControlsVisible] = useState(false);
   const channelRef = useRef<BroadcastChannel | null>(null);
@@ -250,7 +254,7 @@ const BroadcastScreenPage = () => {
       $immersive={isFullscreen && !controlsVisible}
     >
       {currentSrc ? (
-        <Stage>
+        <Stage ref={stageRef}>
           <SlideImage
             key={currentSrc}
             ref={(img: HTMLImageElement | null) => {
@@ -273,7 +277,7 @@ const BroadcastScreenPage = () => {
                 style={stampBoxStyle(
                   stamp.xPct,
                   stamp.yPct,
-                  slideContentFractions(slideNaturalRatio)
+                  slideContentFractions(slideNaturalRatio, stageRatio ?? SLIDE_BOX_ASPECT)
                 )}
                 draggable={false}
               />

--- a/src/pages/broadcast-screen/ui/BroadcastScreenPage.tsx
+++ b/src/pages/broadcast-screen/ui/BroadcastScreenPage.tsx
@@ -252,6 +252,11 @@ const BroadcastScreenPage = () => {
       {currentSrc ? (
         <Stage>
           <SlideImage
+            key={currentSrc}
+            ref={(img: HTMLImageElement | null) => {
+              // 캐시된 이미지는 onLoad 를 놓칠 수 있어 ref 시점에 complete 여부도 확인
+              if (img && img.complete) setSlideNaturalRatio(imageNaturalRatio(img));
+            }}
             src={currentSrc}
             alt={`슬라이드 ${slideIndex + 1}`}
             draggable={false}

--- a/src/pages/rating/ui/QuestionAnswerList.tsx
+++ b/src/pages/rating/ui/QuestionAnswerList.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { MEDIA } from "@/shared/config/breakpoints";
 import type { FeedbackQuestion } from "@/shared/api/feedback-questions";
 
 interface QuestionAnswerListProps {
@@ -46,6 +47,14 @@ const List = styled.div`
   min-height: 0;
   overflow-y: auto;
   padding-right: 0.5vw;
+
+  /* 모바일: 내부 스크롤 대신 페이지 스크롤로 자연 확장 */
+  @media ${MEDIA.mobile} {
+    flex: none;
+    overflow-y: visible;
+    padding-right: 0;
+    gap: 12px;
+  }
 `;
 
 const Field = styled.div`
@@ -73,5 +82,13 @@ const AnswerInput = styled.input`
   }
   &::placeholder {
     color: #767676;
+  }
+
+  /* iOS: 16px 미만 입력창 포커스 시 자동 확대 방지 */
+  @media ${MEDIA.mobile} {
+    border: 1px solid #e5e5ec;
+    border-radius: 6px;
+    padding: 12px;
+    font-size: 16px;
   }
 `;

--- a/src/pages/rating/ui/RatingActionButtons.tsx
+++ b/src/pages/rating/ui/RatingActionButtons.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { MEDIA } from "@/shared/config/breakpoints";
 import DownloadIcon from "@/shared/assets/images/download.svg";
 
 interface RatingActionButtonsProps {
@@ -52,6 +53,10 @@ const Row = styled.div`
   display: flex;
   gap: 1vw;
   align-items: center;
+
+  @media ${MEDIA.mobile} {
+    gap: 12px;
+  }
 `;
 
 const BaseButton = styled.button`
@@ -74,6 +79,14 @@ const BaseButton = styled.button`
     background: #d9d9d9;
     color: #ffffff;
     cursor: not-allowed;
+  }
+
+  /* 터치 타깃 확보 */
+  @media ${MEDIA.mobile} {
+    gap: 6px;
+    padding: 12px 24px;
+    border-radius: 6px;
+    font-size: 14px;
   }
 `;
 

--- a/src/pages/rating/ui/RatingPage.tsx
+++ b/src/pages/rating/ui/RatingPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo, useEffect } from "react";
 import { useParams, useNavigate, useLocation } from "react-router";
 import styled from "styled-components";
+import { MEDIA } from "@/shared/config/breakpoints";
 import { createLogger } from "@/shared/lib/logger";
 
 const log = createLogger("rating");
@@ -300,6 +301,16 @@ const MainLayout = styled.div`
   overflow: hidden;
   background: #fff;
   box-sizing: border-box;
+
+  /* 모바일: 단일 컬럼 + 내부 세로 스크롤 (.page 가 overflow hidden 이므로 여기서 스크롤) */
+  @media ${MEDIA.mobile} {
+    grid-template-columns: 1fr;
+    width: 100%;
+    height: 100%;
+    max-height: none;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+  }
 `;
 
 /* 양옆 빗금 영역 */
@@ -311,6 +322,10 @@ const Side = styled.div`
   justify-content: center;
   align-items: center;
   box-sizing: border-box;
+
+  @media ${MEDIA.mobile} {
+    display: none;
+  }
 `;
 
 const SideInner = styled.div`
@@ -344,6 +359,18 @@ const CenterGrid = styled.div`
   border-left: 0.1vw solid #eaeaea;
   border-right: 0.1vw solid #eaeaea;
   overflow: hidden;
+
+  /* 모바일: 그리드 대신 세로 스택, 페이지 스크롤로 전환 */
+  @media ${MEDIA.mobile} {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    height: auto;
+    max-height: none;
+    padding: 20px 16px 32px;
+    border: none;
+    overflow: visible;
+  }
 `;
 
 /* 각 박스 */
@@ -368,12 +395,21 @@ const Box = styled.div`
 const ThumbnailBox = styled(Box)`
   grid-column: 1;
   grid-row: 1;
+
+  @media ${MEDIA.mobile} {
+    min-height: 180px;
+    padding: 12px 0;
+  }
 `;
 
 /* 좌측 하단 - 별점 */
 const StarRatingBox = styled(Box)`
   grid-column: 1;
   grid-row: 2;
+
+  @media ${MEDIA.mobile} {
+    padding: 20px 0;
+  }
 `;
 
 /* 우측 - 후기 (좌측 두 행 전체 높이) — 발표자 질문이 있을 때 */
@@ -383,18 +419,31 @@ const QuestionsBox = styled(Box)`
   justify-content: flex-start;
   align-items: center;
   overflow: hidden;
+
+  @media ${MEDIA.mobile} {
+    padding: 4px 0;
+    overflow: visible;
+  }
 `;
 
 /* 원본 디자인(질문 없음) - 우측 상단 감사 메시지 */
 const ThanksBox = styled(Box)`
   grid-column: 2;
   grid-row: 1;
+
+  @media ${MEDIA.mobile} {
+    padding: 16px 8px;
+  }
 `;
 
 /* 원본 디자인(질문 없음) - 우측 하단 단일 후기 입력 */
 const CommentBox = styled(Box)`
   grid-column: 2;
   grid-row: 2;
+
+  @media ${MEDIA.mobile} {
+    padding: 4px 0;
+  }
 `;
 
 const ThanksText = styled.div`
@@ -416,6 +465,18 @@ const ThanksText = styled.div`
     color: #333;
     line-height: 1.5;
   }
+
+  @media ${MEDIA.mobile} {
+    img {
+      width: 84px;
+      margin-right: -8px;
+      margin-left: -12px;
+    }
+
+    div {
+      font-size: 14px;
+    }
+  }
 `;
 
 const CommentTextArea = styled.textarea`
@@ -436,6 +497,15 @@ const CommentTextArea = styled.textarea`
     color: #b5b5b5;
     opacity: 0.8;
   }
+
+  /* iOS: 16px 미만 입력창 포커스 시 자동 확대 방지 */
+  @media ${MEDIA.mobile} {
+    min-height: 120px;
+    padding: 10px 12px;
+    border: 1px solid #eaeaea;
+    border-radius: 8px;
+    font-size: 16px;
+  }
 `;
 
 /* 별점 박스 */
@@ -447,12 +517,23 @@ const RatingTitle = styled.h3`
   font-size: 1.4vw;
   margin-bottom: 1vh;
   color: #5c5c5c;
+
+  @media ${MEDIA.mobile} {
+    font-size: 16px;
+    margin-bottom: 8px;
+  }
 `;
 
 const StarImg = styled.img`
   width: 2vw !important;
   height: auto;
   cursor: pointer;
+
+  /* 터치 타깃 확보 */
+  @media ${MEDIA.mobile} {
+    width: 36px !important;
+    padding: 4px;
+  }
   transition:
     transform 0.15s ease,
     filter 0.15s ease;
@@ -513,6 +594,12 @@ const IdentityNotice = styled.div`
   padding: 1vh 1vw;
   font-size: clamp(12px, 0.85vw, 14px);
   line-height: 1.5;
+
+  @media ${MEDIA.mobile} {
+    border: 1px solid #f2b08d;
+    border-radius: 8px;
+    padding: 10px 12px;
+  }
 `;
 
 const IdentityNoticeActions = styled.div`
@@ -540,6 +627,12 @@ const OverwriteNotice = styled.div`
   padding: 1vh 1vw;
   font-size: clamp(12px, 0.85vw, 14px);
   line-height: 1.5;
+
+  @media ${MEDIA.mobile} {
+    border: 1px solid #cdd8f0;
+    border-radius: 8px;
+    padding: 10px 12px;
+  }
 `;
 
 /* 버튼 영역 */

--- a/src/pages/rating/ui/RatingPage.tsx
+++ b/src/pages/rating/ui/RatingPage.tsx
@@ -292,8 +292,11 @@ const MainLayout = styled.div`
   grid-template-columns: 15vw 1fr 15vw;
   width: 100vw;
   min-height: 100vh;
+  min-height: 100dvh;
   height: 100vh;
+  height: 100dvh;
   max-height: 100vh;
+  max-height: 100dvh;
   overflow: hidden;
   background: #fff;
   box-sizing: border-box;
@@ -335,6 +338,7 @@ const CenterGrid = styled.div`
   width: 100%;
   height: 100%;
   max-height: 100vh;
+  max-height: 100dvh;
   padding: 5% 2%;
   box-sizing: border-box;
   border-left: 0.1vw solid #eaeaea;

--- a/src/shared/config/breakpoints.ts
+++ b/src/shared/config/breakpoints.ts
@@ -1,0 +1,17 @@
+// * 반응형 브레이크포인트 단일 소스 (px)
+
+export const BREAKPOINTS = {
+  // 이 값 미만: 모바일 세로 스택 레이아웃
+  mobile: 768,
+  // mobile 이상 ~ 이 값 미만: 태블릿 (데스크톱 레이아웃 유지)
+  tablet: 1024,
+} as const;
+
+// * styled-components 미디어 쿼리 헬퍼 — 사용: @media ${MEDIA.mobile} { ... }
+export const MEDIA = {
+  mobile: `(max-width: ${BREAKPOINTS.mobile - 1}px)`,
+  tabletDown: `(max-width: ${BREAKPOINTS.tablet - 1}px)`,
+  desktop: `(min-width: ${BREAKPOINTS.tablet}px)`,
+  // hover 불가 터치 기기 — hover 의존 UI 분기용
+  touch: "(hover: none) and (pointer: coarse)",
+} as const;

--- a/src/shared/lib/slide-geometry.ts
+++ b/src/shared/lib/slide-geometry.ts
@@ -1,0 +1,62 @@
+// * 슬라이드 스탬프 좌표계 유틸
+//   저장/전송되는 xPct·yPct 는 "레터박스를 제외한 실제 슬라이드 콘텐츠" 기준 %.
+//   각 화면은 컨테이너(박스) 안에 object-fit: contain 으로 이미지를 그리므로,
+//   이미지 원본 비율로 콘텐츠 영역을 계산해 박스 좌표계와 상호 변환한다.
+
+export const SLIDE_BOX_ASPECT = 16 / 9;
+
+// 슬라이드 콘텐츠 폭 대비 스탬프 크기(%) — broadcast 3.4cqw 에서 유래
+export const STAMP_CONTENT_WIDTH_PCT = 3.4;
+
+// 박스 내에서 콘텐츠가 차지하는 영역 (0~1 분율)
+export interface SlideContentFractions {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+export const slideContentFractions = (
+  naturalRatio: number | null | undefined,
+  boxRatio: number = SLIDE_BOX_ASPECT
+): SlideContentFractions => {
+  if (
+    !naturalRatio ||
+    !Number.isFinite(naturalRatio) ||
+    naturalRatio <= 0 ||
+    !Number.isFinite(boxRatio) ||
+    boxRatio <= 0
+  ) {
+    // 비율을 모르면 박스 전체를 콘텐츠로 간주 (16:9 덱과 동일한 기존 동작)
+    return { left: 0, top: 0, width: 1, height: 1 };
+  }
+
+  const width = Math.min(1, naturalRatio / boxRatio);
+  const height = Math.min(1, boxRatio / naturalRatio);
+  return { left: (1 - width) / 2, top: (1 - height) / 2, width, height };
+};
+
+// 콘텐츠 기준 % 좌표 → 박스 기준 CSS 배치 스타일 (크기도 콘텐츠 폭에 비례)
+export const stampBoxStyle = (xPct: number, yPct: number, fractions: SlideContentFractions) => ({
+  left: `${(fractions.left + (xPct / 100) * fractions.width) * 100}%`,
+  top: `${(fractions.top + (yPct / 100) * fractions.height) * 100}%`,
+  width: `${STAMP_CONTENT_WIDTH_PCT * fractions.width}%`,
+});
+
+// 박스 내 클릭 분율(0~1) → 콘텐츠 기준 %. 레터박스 영역이면 null.
+export const boxPointToContentPct = (
+  boxX: number,
+  boxY: number,
+  fractions: SlideContentFractions
+): { xPct: number; yPct: number } | null => {
+  const xPct = ((boxX - fractions.left) / fractions.width) * 100;
+  const yPct = ((boxY - fractions.top) / fractions.height) * 100;
+  if (xPct < 0 || xPct > 100 || yPct < 0 || yPct > 100) return null;
+  return { xPct, yPct };
+};
+
+// img onLoad 에서 원본 비율 추출
+export const imageNaturalRatio = (img: HTMLImageElement): number | null => {
+  if (!img.naturalWidth || !img.naturalHeight) return null;
+  return img.naturalWidth / img.naturalHeight;
+};

--- a/src/shared/lib/use-element-aspect-ratio.ts
+++ b/src/shared/lib/use-element-aspect-ratio.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import type { RefObject } from "react";
+
+// * 요소의 실제 렌더 비율(w/h)을 ResizeObserver 로 추적
+//   슬라이드 박스는 CSS aspect-ratio 16:9 를 선언해도 flex 축소 등으로 비율이
+//   깨질 수 있어, 스탬프 좌표 변환은 항상 실측 비율을 사용한다
+export const useElementAspectRatio = (ref: RefObject<HTMLElement | null>) => {
+  const [ratio, setRatio] = useState<number | null>(null);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element || typeof ResizeObserver === "undefined") return;
+
+    const measure = () => {
+      const rect = element.getBoundingClientRect();
+      if (rect.width > 0 && rect.height > 0) {
+        setRatio(rect.width / rect.height);
+      }
+    };
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [ref]);
+
+  return ratio;
+};

--- a/src/shared/lib/use-immersive-mode.ts
+++ b/src/shared/lib/use-immersive-mode.ts
@@ -1,0 +1,101 @@
+import { useCallback, useEffect, useState } from "react";
+import type { RefObject } from "react";
+
+type FullscreenCapableElement = HTMLElement & {
+  webkitRequestFullscreen?: () => Promise<void> | void;
+};
+
+type FullscreenDocument = Document & {
+  webkitFullscreenElement?: Element | null;
+  webkitExitFullscreen?: () => Promise<void> | void;
+  webkitFullscreenEnabled?: boolean;
+};
+
+type LockableOrientation = ScreenOrientation & {
+  lock?: (orientation: "landscape") => Promise<void>;
+  unlock?: () => void;
+};
+
+// * 몰입(전체화면) 모드 훅
+//   - Element Fullscreen API 지원(데스크톱/안드로이드/아이패드): 네이티브 전체화면
+//   - 미지원(아이폰 Safari): position fixed 오버레이 pseudo-fullscreen 폴백
+//   isImmersive 하나로 두 모드를 동일하게 소비하고, pseudo 여부는 스타일 분기에만 쓴다
+export const useImmersiveMode = (targetRef: RefObject<HTMLElement | null>) => {
+  const [isNativeFullscreen, setIsNativeFullscreen] = useState(false);
+  const [isPseudoFullscreen, setIsPseudoFullscreen] = useState(false);
+
+  useEffect(() => {
+    const handleChange = () => {
+      const doc = document as FullscreenDocument;
+      const activeElement = document.fullscreenElement ?? doc.webkitFullscreenElement;
+      setIsNativeFullscreen(Boolean(activeElement && activeElement === targetRef.current));
+    };
+
+    document.addEventListener("fullscreenchange", handleChange);
+    document.addEventListener("webkitfullscreenchange", handleChange);
+
+    return () => {
+      document.removeEventListener("fullscreenchange", handleChange);
+      document.removeEventListener("webkitfullscreenchange", handleChange);
+    };
+  }, [targetRef]);
+
+  const toggleImmersive = useCallback(async () => {
+    const element = targetRef.current as FullscreenCapableElement | null;
+    if (!element) return;
+
+    const doc = document as FullscreenDocument;
+    const fullscreenAllowed = (document.fullscreenEnabled ?? doc.webkitFullscreenEnabled) !== false;
+    const supportsNative =
+      fullscreenAllowed && Boolean(element.requestFullscreen || element.webkitRequestFullscreen);
+
+    if (!supportsNative) {
+      setIsPseudoFullscreen((prev) => !prev);
+      return;
+    }
+
+    const activeElement = document.fullscreenElement ?? doc.webkitFullscreenElement;
+    const orientation = screen.orientation as LockableOrientation | undefined;
+
+    if (activeElement) {
+      try {
+        orientation?.unlock?.();
+      } catch {
+        /* ignore */
+      }
+      if (document.exitFullscreen) {
+        await document.exitFullscreen();
+        return;
+      }
+      await doc.webkitExitFullscreen?.();
+      return;
+    }
+
+    try {
+      if (element.requestFullscreen) {
+        await element.requestFullscreen();
+      } else {
+        await element.webkitRequestFullscreen?.();
+      }
+    } catch {
+      // 권한 정책 등으로 거부되면 pseudo-fullscreen 으로 폴백
+      setIsPseudoFullscreen(true);
+      return;
+    }
+
+    // 터치 기기(안드로이드)에서는 몰입 모드 진입 시 가로 고정 시도 — 미지원이면 조용히 무시
+    if (window.matchMedia("(hover: none) and (pointer: coarse)").matches) {
+      try {
+        await orientation?.lock?.("landscape");
+      } catch {
+        /* ignore */
+      }
+    }
+  }, [targetRef]);
+
+  return {
+    isImmersive: isNativeFullscreen || isPseudoFullscreen,
+    isPseudoFullscreen,
+    toggleImmersive,
+  };
+};

--- a/src/shared/lib/use-media-query.ts
+++ b/src/shared/lib/use-media-query.ts
@@ -1,0 +1,22 @@
+import { useCallback, useSyncExternalStore } from "react";
+import { MEDIA } from "@/shared/config/breakpoints";
+
+// * matchMedia 구독 훅 — 뷰포트 변화(회전 포함)에 실시간 반응
+export const useMediaQuery = (query: string): boolean => {
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      const mediaQueryList = window.matchMedia(query);
+      mediaQueryList.addEventListener("change", onChange);
+      return () => mediaQueryList.removeEventListener("change", onChange);
+    },
+    [query]
+  );
+
+  const getSnapshot = useCallback(() => window.matchMedia(query).matches, [query]);
+
+  return useSyncExternalStore(subscribe, getSnapshot);
+};
+
+export const useIsMobile = () => useMediaQuery(MEDIA.mobile);
+
+export const useIsTouchDevice = () => useMediaQuery(MEDIA.touch);

--- a/src/shared/lib/use-visual-viewport-height.ts
+++ b/src/shared/lib/use-visual-viewport-height.ts
@@ -12,13 +12,21 @@ export const useVisualViewportHeight = (enabled: boolean) => {
     const root = document.documentElement;
     const update = () => {
       root.style.setProperty("--app-height", `${Math.round(viewport.height)}px`);
+
+      // iOS 는 입력 포커스 시 문서를 위로 밀어 올린다(visualViewport 팬).
+      // 레이아웃이 이미 vv 높이에 맞으므로 스크롤을 되돌려 상단 UI 를 고정한다.
+      if (viewport.offsetTop > 0 || window.scrollY > 0) {
+        window.scrollTo(0, 0);
+      }
     };
 
     update();
     viewport.addEventListener("resize", update);
+    viewport.addEventListener("scroll", update);
 
     return () => {
       viewport.removeEventListener("resize", update);
+      viewport.removeEventListener("scroll", update);
       root.style.removeProperty("--app-height");
     };
   }, [enabled]);

--- a/src/shared/lib/use-visual-viewport-height.ts
+++ b/src/shared/lib/use-visual-viewport-height.ts
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+
+// * 모바일 가상 키보드가 열릴 때 visualViewport 높이를 --app-height(px)로 반영
+//   global.css 의 #root { height: var(--app-height, 100dvh) } 와 짝을 이룬다
+export const useVisualViewportHeight = (enabled: boolean) => {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const viewport = window.visualViewport;
+    if (!viewport) return;
+
+    const root = document.documentElement;
+    const update = () => {
+      root.style.setProperty("--app-height", `${Math.round(viewport.height)}px`);
+    };
+
+    update();
+    viewport.addEventListener("resize", update);
+
+    return () => {
+      viewport.removeEventListener("resize", update);
+      root.style.removeProperty("--app-height");
+    };
+  }, [enabled]);
+};

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -19,7 +19,15 @@ body {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr); /* 헤더 + 나머지 */
   height: 100vh;
+  height: 100dvh;
   overflow: hidden;
+}
+
+/* 모바일 가상 키보드가 열리면 useVisualViewportHeight 훅이 --app-height(px)를 갱신 */
+@supports (height: 100dvh) {
+  #root {
+    height: var(--app-height, 100dvh);
+  }
 }
 
 .HeaderBar {

--- a/src/widgets/presentation-layout/ui/viewer/SlideContainer.tsx
+++ b/src/widgets/presentation-layout/ui/viewer/SlideContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import type { SyntheticEvent } from "react";
 import styled, { css } from "styled-components";
 import { HighlightedSlideStyles } from "./SlideViewer.styles";
@@ -6,7 +6,9 @@ import {
   slideContentFractions,
   stampBoxStyle,
   imageNaturalRatio,
+  SLIDE_BOX_ASPECT,
 } from "@/shared/lib/slide-geometry";
+import { useElementAspectRatio } from "@/shared/lib/use-element-aspect-ratio";
 
 /**
  * 공용 슬라이드 컨테이너
@@ -26,8 +28,11 @@ const SlideContainer = ({
   const hasSrc = typeof src === "string" && src.length > 0;
 
   // 레터박스를 제외한 실제 슬라이드 콘텐츠 영역 — 스탬프 좌표(콘텐츠 기준 %)의 기준
+  // 박스는 flex 축소로 16:9 에서 벗어날 수 있으므로 실측 비율을 쓴다
+  const boxRef = useRef<HTMLDivElement | null>(null);
+  const boxRatio = useElementAspectRatio(boxRef);
   const [naturalRatio, setNaturalRatio] = useState<number | null>(null);
-  const contentFractions = slideContentFractions(naturalRatio);
+  const contentFractions = slideContentFractions(naturalRatio, boxRatio ?? SLIDE_BOX_ASPECT);
 
   const handleImageLoad = (e: SyntheticEvent<HTMLImageElement>) => {
     setNaturalRatio(imageNaturalRatio(e.currentTarget));
@@ -41,7 +46,7 @@ const SlideContainer = ({
   };
 
   return (
-    <SlideBox highlight={highlight} data-testid={testId}>
+    <SlideBox ref={boxRef} highlight={highlight} data-testid={testId}>
       {hasSrc ? (
         <img
           key={src}

--- a/src/widgets/presentation-layout/ui/viewer/SlideContainer.tsx
+++ b/src/widgets/presentation-layout/ui/viewer/SlideContainer.tsx
@@ -79,8 +79,11 @@ const SlideBox = styled.div<{ highlight?: boolean }>`
 const StampImage = styled.img`
   position: absolute;
   transform: translate(-50%, -50%);
-  width: 25px;
-  height: 25px;
+  /* 슬라이드 폭 대비 상대 크기 — broadcast(3.4cqw)와 동일 비율로 기기 무관하게 일치 */
+  width: 3.4%;
+  height: auto;
+  aspect-ratio: 1;
+  object-fit: contain;
   pointer-events: none;
 `;
 

--- a/src/widgets/presentation-layout/ui/viewer/SlideContainer.tsx
+++ b/src/widgets/presentation-layout/ui/viewer/SlideContainer.tsx
@@ -33,10 +33,19 @@ const SlideContainer = ({
     setNaturalRatio(imageNaturalRatio(e.currentTarget));
   };
 
+  // 캐시된 이미지는 onLoad 를 놓칠 수 있어 ref 시점에 complete 여부도 확인
+  const attachImage = (img: HTMLImageElement | null) => {
+    if (img && img.complete) {
+      setNaturalRatio(imageNaturalRatio(img));
+    }
+  };
+
   return (
     <SlideBox highlight={highlight} data-testid={testId}>
       {hasSrc ? (
         <img
+          key={src}
+          ref={attachImage}
           src={src}
           alt={alt}
           onLoad={handleImageLoad}

--- a/src/widgets/presentation-layout/ui/viewer/SlideContainer.tsx
+++ b/src/widgets/presentation-layout/ui/viewer/SlideContainer.tsx
@@ -1,6 +1,12 @@
-import React from "react";
+import React, { useState } from "react";
+import type { SyntheticEvent } from "react";
 import styled, { css } from "styled-components";
 import { HighlightedSlideStyles } from "./SlideViewer.styles";
+import {
+  slideContentFractions,
+  stampBoxStyle,
+  imageNaturalRatio,
+} from "@/shared/lib/slide-geometry";
 
 /**
  * 공용 슬라이드 컨테이너
@@ -19,12 +25,21 @@ const SlideContainer = ({
 
   const hasSrc = typeof src === "string" && src.length > 0;
 
+  // 레터박스를 제외한 실제 슬라이드 콘텐츠 영역 — 스탬프 좌표(콘텐츠 기준 %)의 기준
+  const [naturalRatio, setNaturalRatio] = useState<number | null>(null);
+  const contentFractions = slideContentFractions(naturalRatio);
+
+  const handleImageLoad = (e: SyntheticEvent<HTMLImageElement>) => {
+    setNaturalRatio(imageNaturalRatio(e.currentTarget));
+  };
+
   return (
     <SlideBox highlight={highlight} data-testid={testId}>
       {hasSrc ? (
         <img
           src={src}
           alt={alt}
+          onLoad={handleImageLoad}
           style={{
             width: "100%",
             height: "100%",
@@ -44,10 +59,7 @@ const SlideContainer = ({
           <StampImage
             key={stamp.id || `${stamp.xPct}-${stamp.yPct}-${index}`}
             src={stamp.src}
-            style={{
-              top: `${stamp.yPct}%`,
-              left: `${stamp.xPct}%`,
-            }}
+            style={stampBoxStyle(stamp.xPct, stamp.yPct, contentFractions)}
             alt="reaction"
           />
         ))}


### PR DESCRIPTION
## What

Mobile/tablet support for the audience experience, plus a rework of reaction-sticker coordinates that fixes position mismatches across all slide surfaces.

### Mobile audience (<768px)
- Portrait-first stacked layout: top bar (follow toggle + `‹ n/N ›` pager) / full-width slide / scrollable emoji strip / live Q&A chat with pinned input; slides sidebar hidden on phones
- Slide navigation by horizontal swipe or pager buttons — reuses the existing audience-select logic (unlock limits, unfollow, WS broadcast); swipes never place stamps
- `useImmersiveMode`: native Element Fullscreen on desktop/Android/iPad, `position: fixed` pseudo-fullscreen fallback on iPhone Safari, Android landscape-lock attempt
- Keyboard handling via `visualViewport`: layout shrinks to keep the question input visible and the slide pinned (no whole-page shift)
- Feature toggles reshape the stack live (sticker/question off → region collapses)
- Touch polish: 44px targets, `touch-action: manipulation`, no hover tooltips on touch, 16px inputs to prevent iOS focus-zoom, `100dvh` fixes
- RatingPage single-column scroll layout; waiting/ended screens responsive

### Reaction sticker coordinates (all surfaces)
- `xPct`/`yPct` now mean **percent of the rendered slide content** (letterbox excluded), not the container box — same slide point on phone, presenter, broadcast, and AI report
- Sticker size is 3.4% of slide width everywhere (was fixed 25px)
- Box ratio is **measured** (`useElementAspectRatio`, ResizeObserver) — the slide box deforms up to ~4.3:1 under flex compression in short/wide windows, which is when letterboxes appear; stickers now track the slide through resizes
- Tap-time ratio reads + cached-image (`img.complete`) handling close the races that fell back to the old frame; letterbox-bar taps are ignored

## Verification
- `pnpm typecheck` / `pnpm lint` (0 errors) / `pnpm build` clean
- Playwright-driven checks against the mock harness at 390×844, 375×667, desktop, and stretched presenter windows (1800×750 → 2300×700), with 16:9, 4:3, and 2:1 decks — stamp lands at the same content fraction on every surface (±0.5%)
- Field-tested on iPhone

## Notes
- Stamps recorded **before** this branch on non-16:9 decks replay slightly shifted (stored in the old box-relative frame)
- Pre-existing test issues (fail identically on `dev`, verified by reverse-apply): 3 unit tests; `presenter-prepare.spec.ts:10` expects a `실시간 피드백` control absent from the DOM; `live-interactions` races the join-warning modal it never dismisses
- Deferred: iPhone canvas→video "theater mode" (needs real-device spike)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
