### PR TITLE
refactor: migrate server state to TanStack Query v5

### DIFF
--- a/.claude/rules/fsd-architecture.md
+++ b/.claude/rules/fsd-architecture.md
@@ -44,7 +44,9 @@ Every slice exposes its API through `index.ts` only. Never deep-import slice int
 - Pure functions → `src/shared/lib/` · API calls → `src/shared/api/` · constants → `src/shared/config/` · generic components → `src/shared/ui/`
 - An entity owns its types, Jotai atoms, and pure domain logic. Page-specific orchestration stays in `pages/*/model/`
 - `src/shared/ui/` components must be generic — no business concepts (rooms, questions); those belong in `entities/*/ui/` or a page
-- Global state: Jotai atoms, not React Context
+- Global client/UI state: Jotai atoms, not React Context. Server state: TanStack Query —
+  `queryOptions` + key factories live beside the axios fns in `src/shared/api/`; consumers
+  apply only per-use policy (`enabled`, `select`, overrides)
 - `src/app/` only wires routes (`router.tsx`) and global providers (`App.tsx`) — no business logic
 
 ## Conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,9 @@ FSD layers, lowest → highest: `shared` → `entities` → `features` → `widg
 Imports flow strictly toward lower layers; each slice's public API is its `index.ts`.
 Details: `src/AGENTS.md` and `.claude/rules/`.
 
-- Global state: Jotai atoms (not React Context)
+- Client/UI state: Jotai atoms (not React Context); server state: TanStack Query v5
+  (`queryOptions` factories co-located with the axios fns in `src/shared/api/`,
+  provider in `src/app/main.tsx`)
 - Styling: styled-components v6, co-located `.styles.ts` files
 - All backend I/O in `src/shared/api/` — axios instances plus the `WebSocketService`
   singleton (STOMP over SockJS) in `src/shared/api/websocket.ts`

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Boini는 발표자와 청중이 실시간으로 상호작용할 수 있는 프�
 주요 라이브러리:
 
 - `axios`
+- `@tanstack/react-query`
 - `@stomp/stompjs`, `sockjs-client`
 - `qrcode.react`
 - `uuid`

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@stomp/stompjs": "^7.2.1",
+    "@tanstack/react-query": "^5.101.2",
     "axios": "^1.12.2",
     "jotai": "^2.19.0",
     "qrcode.react": "^4.2.0",
@@ -41,6 +42,7 @@
     "@eslint/js": "^8.57.1",
     "@playwright/experimental-ct-react": "^1.58.2",
     "@playwright/test": "^1.58.2",
+    "@tanstack/react-query-devtools": "^5.101.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^25.5.0",

--- a/playwright/index.tsx
+++ b/playwright/index.tsx
@@ -1,1 +1,14 @@
+import { beforeMount } from "@playwright/experimental-ct-react/hooks";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "../src/styles/global.css";
+
+beforeMount(async ({ App }) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  );
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@stomp/stompjs':
         specifier: ^7.2.1
         version: 7.3.0
+      '@tanstack/react-query':
+        specifier: ^5.101.2
+        version: 5.101.2(react@19.2.4)
       axios:
         specifier: ^1.12.2
         version: 1.13.6
@@ -48,6 +51,9 @@ importers:
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
+      '@tanstack/react-query-devtools':
+        specifier: ^5.101.2
+        version: 5.101.2(@tanstack/react-query@5.101.2(react@19.2.4))(react@19.2.4)
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -802,6 +808,23 @@ packages:
 
   '@stomp/stompjs@7.3.0':
     resolution: {integrity: sha512-nKMLoFfJhrQAqkvvKd1vLq/cVBGCMwPRCD0LqW7UT1fecRx9C3GoKEIR2CYwVuErGeZu8w0kFkl2rlhPlqHVgQ==}
+
+  '@tanstack/query-core@5.101.2':
+    resolution: {integrity: sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==}
+
+  '@tanstack/query-devtools@5.101.2':
+    resolution: {integrity: sha512-o+wHcqgN7Pp0s8v1i0UGq/ZrrEKrxdIiMQmKRdYb2w7NPtylYSJ4+wg/tIn71m9DLstwUwdEGAvROdly6HXP6w==}
+
+  '@tanstack/react-query-devtools@5.101.2':
+    resolution: {integrity: sha512-eU7HctdA9gDjqoERoEdzLbw9DiqnBDfh5+Hu0u26gjqoHJezOpQAuiesDL2VvkU+2cPV76zgv0tMZsOrI4LjnQ==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.101.2
+      react: ^18 || ^19
+
+  '@tanstack/react-query@5.101.2':
+    resolution: {integrity: sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -3248,6 +3271,21 @@ snapshots:
     optional: true
 
   '@stomp/stompjs@7.3.0': {}
+
+  '@tanstack/query-core@5.101.2': {}
+
+  '@tanstack/query-devtools@5.101.2': {}
+
+  '@tanstack/react-query-devtools@5.101.2(@tanstack/react-query@5.101.2(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/query-devtools': 5.101.2
+      '@tanstack/react-query': 5.101.2(react@19.2.4)
+      react: 19.2.4
+
+  '@tanstack/react-query@5.101.2(react@19.2.4)':
+    dependencies:
+      '@tanstack/query-core': 5.101.2
+      react: 19.2.4
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -43,4 +43,5 @@ from outside the slice.
 - `widgets/` — app-header, presentation-layout, slides-sidebar
 - `styles/` — single `global.css`
 
-Styling: styled-components v6, co-located `.styles.ts`. Global state: Jotai atoms.
+Styling: styled-components v6, co-located `.styles.ts`. Client/UI state: Jotai atoms.
+Server state: TanStack Query v5 (`queryOptions` factories in `src/shared/api/`).

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -1,11 +1,17 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { RouterProvider } from "react-router";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import router from "./router";
+import queryClient from "./query-client";
 import "../styles/global.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
   </React.StrictMode>
 );

--- a/src/app/query-client.ts
+++ b/src/app/query-client.ts
@@ -1,0 +1,14 @@
+import { QueryClient } from "@tanstack/react-query";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      staleTime: 30_000,
+      // Hundreds of audience clients may be connected; window-focus refetch storms must stay off.
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
+export default queryClient;

--- a/src/entities/reaction/model/useStickerLoader.ts
+++ b/src/entities/reaction/model/useStickerLoader.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
-import { getAllStickers } from "@/shared/api/sticker";
+import { useQueryClient } from "@tanstack/react-query";
+import { roomStickersQuery } from "@/shared/api/sticker";
 import { SELECTED_EMOJI_ICONS } from "@/entities/reaction";
 import { createLogger } from "@/shared/lib/logger";
 
@@ -16,6 +17,7 @@ interface UseStickerLoaderParams {
 }
 
 const useStickerLoader = ({ roomId, addLocalStamp, reactionsReady }: UseStickerLoaderParams) => {
+  const queryClient = useQueryClient();
   const stickersLoadedRef = useRef<string | false>(false);
 
   useEffect(() => {
@@ -30,7 +32,7 @@ const useStickerLoader = ({ roomId, addLocalStamp, reactionsReady }: UseStickerL
 
     const loadStickers = async () => {
       try {
-        const stickers = await getAllStickers(roomId);
+        const stickers = await queryClient.fetchQuery(roomStickersQuery(roomId));
 
         if (!Array.isArray(stickers) || stickers.length === 0) {
           stickersLoadedRef.current = loadKey;
@@ -79,7 +81,7 @@ const useStickerLoader = ({ roomId, addLocalStamp, reactionsReady }: UseStickerL
     return () => {
       clearTimeout(timeoutId);
     };
-  }, [roomId, addLocalStamp, reactionsReady]);
+  }, [roomId, addLocalStamp, reactionsReady, queryClient]);
 };
 
 export default useStickerLoader;

--- a/src/entities/session/model/usePdfDownloadPolicy.ts
+++ b/src/entities/session/model/usePdfDownloadPolicy.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
 import { updatePdfDownloadPolicy } from "@/shared/api/pdf-download";
 import { storageKeys } from "@/shared/config/storage-keys";
 import { createLogger } from "@/shared/lib/logger";
@@ -43,7 +44,6 @@ export function usePdfDownloadPolicy({ roomId, initialEnabled }: UsePdfDownloadP
     [initialEnabled, storageKey]
   );
   const [enabled, setEnabled] = useState(resolveInitialEnabled);
-  const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -51,32 +51,41 @@ export function usePdfDownloadPolicy({ roomId, initialEnabled }: UsePdfDownloadP
     setError(null);
   }, [resolveInitialEnabled]);
 
-  const setPolicyEnabled = useCallback(
-    async (nextEnabled: boolean) => {
+  const { mutateAsync, isPending: saving } = useMutation({
+    mutationFn: ({ targetRoomId, nextEnabled }: { targetRoomId: string; nextEnabled: boolean }) =>
+      updatePdfDownloadPolicy(targetRoomId, nextEnabled),
+    onMutate: ({ nextEnabled }) => {
       const previousEnabled = enabled;
       setEnabled(nextEnabled);
       setError(null);
+      return { previousEnabled };
+    },
+    onSuccess: (savedEnabled) => {
+      setEnabled(savedEnabled);
+      writeStoredPolicy(storageKey, savedEnabled);
+    },
+    onError: (policyError, _variables, context) => {
+      log.error("Failed to update PDF download policy", policyError);
+      if (context) setEnabled(context.previousEnabled);
+      setError("다운로드 설정을 저장하지 못했습니다.");
+    },
+  });
 
+  const setPolicyEnabled = useCallback(
+    async (nextEnabled: boolean) => {
       if (!roomId) {
+        setEnabled(nextEnabled);
+        setError(null);
         return nextEnabled;
       }
 
-      setSaving(true);
       try {
-        const savedEnabled = await updatePdfDownloadPolicy(roomId, nextEnabled);
-        setEnabled(savedEnabled);
-        writeStoredPolicy(storageKey, savedEnabled);
-        return savedEnabled;
-      } catch (policyError) {
-        log.error("Failed to update PDF download policy", policyError);
-        setEnabled(previousEnabled);
-        setError("다운로드 설정을 저장하지 못했습니다.");
+        return await mutateAsync({ targetRoomId: roomId, nextEnabled });
+      } catch {
         return null;
-      } finally {
-        setSaving(false);
       }
     },
-    [enabled, roomId, storageKey]
+    [roomId, mutateAsync]
   );
 
   return {

--- a/src/entities/slide-note/model/usePresenterSlideNotes.ts
+++ b/src/entities/slide-note/model/usePresenterSlideNotes.ts
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { fetchSlideNotes, saveSlideNote, saveSlideNoteKeepalive } from "@/shared/api/presentation";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  presentationKeys,
+  saveSlideNote,
+  saveSlideNoteKeepalive,
+  slideNotesQuery,
+} from "@/shared/api/presentation";
+import type { SlideNoteItem } from "@/shared/api/presentation";
 import { SESSION_BEFORE_START_EVENT } from "@/shared/config/session-events";
 
 interface UsePresenterSlideNotesParams {
@@ -17,8 +24,9 @@ export function usePresenterSlideNotes({
   presenterToken,
   editable = false,
 }: UsePresenterSlideNotesParams) {
+  const queryClient = useQueryClient();
   const [notesByPage, setNotesByPage] = useState<Record<number, string>>({});
-  const [loading, setLoading] = useState(false);
+  // One error field fed by both the initial fetch and save failures; last write wins.
   const [error, setError] = useState<Error | null>(null);
   const timersRef = useRef<Record<number, ReturnType<typeof setTimeout>>>({});
   const latestNotesRef = useRef(notesByPage);
@@ -48,66 +56,98 @@ export function usePresenterSlideNotes({
     }
   }, []);
 
+  const notesEnabled = Boolean(roomId && deckId && presenterToken);
+
+  const {
+    data: fetchedNotes,
+    isLoading: loading,
+    isError: notesFetchFailed,
+    error: notesFetchError,
+  } = useQuery({
+    ...slideNotesQuery({
+      roomId: roomId ?? "",
+      deckId: deckId ?? "",
+      presenterToken: presenterToken ?? "",
+    }),
+    enabled: notesEnabled,
+  });
+
+  // Clear any pending debounced saves when the target presentation changes.
   useEffect(() => {
     Object.values(timersRef.current).forEach(clearTimeout);
     timersRef.current = {};
+  }, [roomId, deckId, presenterToken]);
 
-    if (!roomId || !deckId || !presenterToken) {
+  // Seed local notes from the fetched result. Pages with a pending debounced save
+  // keep their local (newer) value so a reseed cannot wipe in-flight edits.
+  useEffect(() => {
+    if (!notesEnabled) {
       setNotesByPage({});
       return;
     }
-
-    const controller = new AbortController();
-    setLoading(true);
+    if (fetchedNotes === undefined) return;
+    const next = fetchedNotes.reduce<Record<number, string>>((acc, item) => {
+      acc[item.page] = item.notes;
+      return acc;
+    }, {});
+    setNotesByPage((prev) => {
+      for (const page of Object.keys(timersRef.current).map(Number)) {
+        if (prev[page] !== undefined) next[page] = prev[page];
+      }
+      return next;
+    });
     setError(null);
+  }, [notesEnabled, fetchedNotes]);
 
-    fetchSlideNotes({ roomId, deckId, presenterToken, signal: controller.signal })
-      .then((items) => {
-        if (controller.signal.aborted) return;
-        const next = items.reduce<Record<number, string>>((acc, item) => {
-          acc[item.page] = item.notes;
-          return acc;
-        }, {});
-        setNotesByPage(next);
+  useEffect(() => {
+    if (!notesFetchFailed) return;
+    setError(
+      notesFetchError instanceof Error ? notesFetchError : new Error(String(notesFetchError))
+    );
+    setNotesByPage({});
+  }, [notesFetchFailed, notesFetchError]);
+
+  const savePageNote = useCallback(
+    (page: number, notes: string): Promise<void> => {
+      const context = saveContextRef.current;
+      if (!context.editable || !context.roomId || !context.deckId || !context.presenterToken) {
+        return Promise.resolve();
+      }
+
+      const noteKey = presentationKeys.slideNotes(
+        context.roomId,
+        context.deckId,
+        context.presenterToken
+      );
+
+      return saveSlideNote({
+        roomId: context.roomId,
+        deckId: context.deckId,
+        presenterToken: context.presenterToken,
+        page,
+        notes,
       })
-      .catch((err: any) => {
-        if (controller.signal.aborted) return;
-        setError(err instanceof Error ? err : new Error(String(err)));
-        setNotesByPage({});
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) setLoading(false);
-      });
-
-    return () => controller.abort();
-  }, [roomId, deckId, presenterToken]);
-
-  const savePageNote = useCallback((page: number, notes: string): Promise<void> => {
-    const context = saveContextRef.current;
-    if (!context.editable || !context.roomId || !context.deckId || !context.presenterToken) {
-      return Promise.resolve();
-    }
-
-    return saveSlideNote({
-      roomId: context.roomId,
-      deckId: context.deckId,
-      presenterToken: context.presenterToken,
-      page,
-      notes,
-    })
-      .then((saved) => {
-        if (!mountedRef.current) return;
-        setError(null);
-        setNotesByPage((prev) => {
-          if (prev[page] !== notes) return prev;
-          return { ...prev, [page]: saved.notes };
+        .then((saved) => {
+          // Write through to the cache even after unmount — a remount within staleTime
+          // (prepare → present) seeds from this entry and must not revert to pre-edit notes.
+          queryClient.setQueryData<SlideNoteItem[]>(noteKey, (prev) => {
+            const rest = (prev ?? []).filter((item) => item.page !== saved.page);
+            return saved.notes ? [...rest, saved] : rest;
+          });
+          if (!mountedRef.current) return;
+          setError(null);
+          setNotesByPage((prev) => {
+            if (prev[page] !== notes) return prev;
+            return { ...prev, [page]: saved.notes };
+          });
+        })
+        .catch((err: any) => {
+          if (!mountedRef.current) return;
+          setError(err instanceof Error ? err : new Error(String(err)));
         });
-      })
-      .catch((err: any) => {
-        if (!mountedRef.current) return;
-        setError(err instanceof Error ? err : new Error(String(err)));
-      });
-  }, []);
+    },
+    [queryClient]
+  );
 
   const flushPendingSaves = useCallback(
     (useKeepalive = false): Promise<void> => {

--- a/src/entities/slide/model/useSlideImage.ts
+++ b/src/entities/slide/model/useSlideImage.ts
@@ -1,17 +1,6 @@
-import { useEffect, useMemo, useState, useCallback } from "react";
-import { getOriginalSlideUrl } from "@/shared/api/presentation";
-
-interface SlideImageState {
-  imageUrl: string | null;
-  loading: boolean;
-  error: Error | null;
-}
-
-const createInitialState = (): SlideImageState => ({
-  imageUrl: null,
-  loading: false,
-  error: null,
-});
+import { useCallback, useMemo } from "react";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { slideImageQuery } from "@/shared/api/presentation";
 
 const normalizeSlideNumber = (value: any): number | null => {
   const parsed = Number(value);
@@ -36,66 +25,26 @@ const useSlideImage = ({
   const shouldLoad =
     Boolean(enabled) && Boolean(roomId) && Boolean(deckId) && normalizedSlideNumber !== null;
 
-  const [state, setState] = useState<SlideImageState>(createInitialState);
-
-  useEffect(() => {
-    if (!shouldLoad) {
-      setState(createInitialState());
-      return () => {};
-    }
-
-    let cancelled = false;
-
-    setState((prev) => ({
-      imageUrl: prev.imageUrl,
-      loading: true,
-      error: null,
-    }));
-
-    getOriginalSlideUrl(roomId!, deckId!, normalizedSlideNumber!)
-      .then((url) => {
-        if (!cancelled) {
-          setState({ imageUrl: url ?? null, loading: false, error: null });
-        }
-      })
-      .catch((error) => {
-        if (!cancelled) {
-          setState({ imageUrl: null, loading: false, error });
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [shouldLoad, roomId, deckId, normalizedSlideNumber]);
+  const { data, isFetching, error, refetch } = useQuery({
+    ...slideImageQuery(roomId ?? "", deckId ?? "", normalizedSlideNumber ?? 0),
+    enabled: shouldLoad,
+    // Keep the previous slide visible while the next one loads when params change.
+    placeholderData: keepPreviousData,
+  });
 
   const reload = useCallback(async () => {
-    if (!shouldLoad) {
-      setState(createInitialState());
-      return null;
-    }
-
-    setState((prev) => ({
-      imageUrl: prev.imageUrl,
-      loading: true,
-      error: null,
-    }));
-
-    try {
-      const url = await getOriginalSlideUrl(roomId!, deckId!, normalizedSlideNumber!);
-      setState({ imageUrl: url ?? null, loading: false, error: null });
-      return url ?? null;
-    } catch (error: any) {
-      setState({ imageUrl: null, loading: false, error });
-      throw error;
-    }
-  }, [shouldLoad, roomId, deckId, normalizedSlideNumber]);
+    if (!shouldLoad) return null;
+    // refetch never throws; surface a failed fetch by inspecting the result.
+    const result = await refetch();
+    if (result.error) throw result.error;
+    return result.data ?? null;
+  }, [shouldLoad, refetch]);
 
   return {
-    imageUrl: state.imageUrl,
-    loading: state.loading,
-    error: state.error,
-    hasImage: Boolean(state.imageUrl),
+    imageUrl: shouldLoad ? (data ?? null) : null,
+    loading: shouldLoad ? isFetching : false,
+    error: shouldLoad ? error : null,
+    hasImage: shouldLoad ? Boolean(data) : false,
     reload,
   };
 };

--- a/src/entities/slide/model/useSlideLoader.ts
+++ b/src/entities/slide/model/useSlideLoader.ts
@@ -1,5 +1,6 @@
-import { useState, useEffect, useCallback } from "react";
-import { fetchAllOriginalSlideUrls } from "@/shared/api/presentation";
+import { useCallback, useMemo } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { presentationKeys, slideUrlsQuery } from "@/shared/api/presentation";
 
 interface UseSlideLoaderParams {
   roomId: string | null;
@@ -27,61 +28,40 @@ export const useSlideLoader = ({
   deckId,
   totalPages,
 }: UseSlideLoaderParams): UseSlideLoaderReturn => {
-  const [slides, setSlides] = useState<(string | null)[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
+  const queryClient = useQueryClient();
+  const enabled = Boolean(roomId && deckId && totalPages);
 
-  const loadSlides = useCallback(
-    async ({ signal }: { signal?: AbortSignal } = {}) => {
-      if (!roomId || !deckId || !totalPages) return;
-      if (signal?.aborted) return;
+  const { data, isFetching, error, refetch } = useQuery({
+    ...slideUrlsQuery(roomId ?? "", deckId ?? "", totalPages ?? 0),
+    enabled,
+  });
 
-      setLoading(true);
-      setError(null);
-
-      try {
-        const urls = await fetchAllOriginalSlideUrls(roomId, deckId, totalPages);
-        if (signal?.aborted) return;
-        setSlides(urls);
-      } catch (err: any) {
-        if (signal?.aborted) return;
-        setError(err instanceof Error ? err : new Error(String(err)));
-      } finally {
-        if (!signal?.aborted) {
-          setLoading(false);
-        }
-      }
-    },
-    [roomId, deckId, totalPages]
-  );
-
-  useEffect(() => {
-    if (!roomId || !deckId || !totalPages) return;
-
-    const controller = new AbortController();
-    loadSlides({ signal: controller.signal });
-
-    return () => {
-      controller.abort();
-    };
-  }, [roomId, deckId, totalPages, loadSlides]);
+  const slides = useMemo(() => data ?? [], [data]);
+  const loading = isFetching;
 
   const retry = useCallback(() => {
     if (!roomId || !deckId || !totalPages) return;
-    loadSlides();
-  }, [roomId, deckId, totalPages, loadSlides]);
+    refetch();
+  }, [roomId, deckId, totalPages, refetch]);
 
   const applySlideReady = useCallback(
     (pageIndex: number, imageUrl: string) => {
-      setSlides((prev) => {
-        const len = Math.max(prev.length, totalPages ?? 0, pageIndex + 1);
-        const next =
-          prev.length === len ? [...prev] : Array.from({ length: len }, (_, i) => prev[i] ?? null);
-        if (!next[pageIndex]) next[pageIndex] = imageUrl;
-        return next;
-      });
+      queryClient.setQueryData<(string | null)[]>(
+        presentationKeys.slides(roomId ?? "", deckId ?? "", totalPages ?? 0),
+        (prev) => {
+          // The slideReady patch can arrive before the initial fetch resolves, so prev may be undefined.
+          const base = prev ?? [];
+          const len = Math.max(base.length, totalPages ?? 0, pageIndex + 1);
+          const next =
+            base.length === len
+              ? [...base]
+              : Array.from({ length: len }, (_, i) => base[i] ?? null);
+          if (!next[pageIndex]) next[pageIndex] = imageUrl;
+          return next;
+        }
+      );
     },
-    [totalPages]
+    [queryClient, roomId, deckId, totalPages]
   );
 
   const hasReadySlide = slides.some((s) => !!s);

--- a/src/features/feedback-questions/model/useFeedbackQuestions.ts
+++ b/src/features/feedback-questions/model/useFeedbackQuestions.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  getFeedbackQuestions,
+  feedbackQuestionsKeys,
+  feedbackQuestionsQuery,
   saveFeedbackQuestions,
   type FeedbackQuestion,
 } from "@/shared/api/feedback-questions";
@@ -14,35 +16,33 @@ const padRows = (values: string[]): string[] => {
   return next;
 };
 
+const toRows = (questions: FeedbackQuestion[]): string[] => {
+  const sorted = [...questions].sort((a, b) => a.orderIndex - b.orderIndex);
+  return padRows(sorted.map((q) => q.questionText));
+};
+
 export function useFeedbackQuestions(roomId: string | undefined, isOpen: boolean) {
+  const queryClient = useQueryClient();
+  // rows stays local + editable, seeded from the query result.
   const [rows, setRows] = useState<string[]>(padRows([]));
-  const [loading, setLoading] = useState(false);
-  const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const { data, isLoading, isError } = useQuery({
+    ...feedbackQuestionsQuery(roomId ?? ""),
+    enabled: isOpen && !!roomId,
+  });
+
   useEffect(() => {
-    if (!isOpen || !roomId) return;
-    let cancelled = false;
-    setLoading(true);
+    if (data === undefined) return;
+    setRows(toRows(data));
     setError(null);
-    getFeedbackQuestions(roomId)
-      .then((questions: FeedbackQuestion[]) => {
-        if (cancelled) return;
-        const sorted = [...questions].sort((a, b) => a.orderIndex - b.orderIndex);
-        setRows(padRows(sorted.map((q) => q.questionText)));
-      })
-      .catch(() => {
-        if (cancelled) return;
-        setError("질문을 불러오지 못했어요. 새로 작성할 수 있습니다.");
-        setRows(padRows([]));
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [isOpen, roomId]);
+  }, [data]);
+
+  useEffect(() => {
+    if (!isError) return;
+    setError("질문을 불러오지 못했어요. 새로 작성할 수 있습니다.");
+    setRows(padRows([]));
+  }, [isError]);
 
   const setRow = useCallback((index: number, value: string) => {
     setRows((prev) => prev.map((row, i) => (i === index ? value : row)));
@@ -52,28 +52,34 @@ export function useFeedbackQuestions(roomId: string | undefined, isOpen: boolean
     setRows((prev) => (prev.length >= MAX_ROWS ? prev : [...prev, ""]));
   }, []);
 
+  const { mutateAsync, isPending: saving } = useMutation({
+    mutationFn: (questions: FeedbackQuestion[]) => saveFeedbackQuestions(roomId ?? "", questions),
+    onSuccess: () => {
+      if (roomId) {
+        queryClient.invalidateQueries({ queryKey: feedbackQuestionsKeys.all(roomId) });
+      }
+    },
+  });
+
   const save = useCallback(async (): Promise<boolean> => {
     if (!roomId) return false;
     const questions: FeedbackQuestion[] = rows
       .map((text) => text.trim())
       .filter((text) => text.length > 0)
       .map((questionText, orderIndex) => ({ orderIndex, questionText }));
-    setSaving(true);
     setError(null);
     try {
-      await saveFeedbackQuestions(roomId, questions);
+      await mutateAsync(questions);
       return true;
     } catch {
       setError("저장에 실패했어요. 다시 시도해주세요.");
       return false;
-    } finally {
-      setSaving(false);
     }
-  }, [roomId, rows]);
+  }, [roomId, rows, mutateAsync]);
 
   return {
     rows,
-    loading,
+    loading: isLoading,
     saving,
     error,
     canAddMore: rows.length < MAX_ROWS,

--- a/src/pages/ai-report/model/useRoomStickers.ts
+++ b/src/pages/ai-report/model/useRoomStickers.ts
@@ -1,8 +1,6 @@
-import { useEffect, useMemo, useState } from "react";
-import { getAllStickers } from "@/shared/api/sticker";
-import { createLogger } from "@/shared/lib/logger";
-
-const log = createLogger("ai-report");
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { roomStickersQuery } from "@/shared/api/sticker";
 
 export interface SlideSticker {
   id: string;
@@ -14,54 +12,39 @@ export interface SlideSticker {
 
 const buildKey = (emoji: number, slide: number) => `${emoji}:${slide}`;
 
+// select 메모이제이션을 위해 훅 밖의 안정 참조로 둔다.
+const normalizeStickers = (raw: any[]): SlideSticker[] => {
+  const normalized: SlideSticker[] = [];
+  (raw ?? []).forEach((item: any, index: number) => {
+    const emoji = Number(item?.emoji);
+    const slide = Number(item?.slide);
+    const xPct = Number(item?.x ?? item?.xPct);
+    const yPct = Number(item?.y ?? item?.yPct);
+    if (
+      !Number.isFinite(emoji) ||
+      !Number.isFinite(slide) ||
+      slide < 1 ||
+      !Number.isFinite(xPct) ||
+      !Number.isFinite(yPct)
+    ) {
+      return;
+    }
+    normalized.push({ id: `${emoji}-${slide}-${index}`, emoji, slide, xPct, yPct });
+  });
+  return normalized;
+};
+
 /**
  * 룸의 전체 스티커(좌표 포함)를 한 번만 불러와 (emoji, slide) 별로 그룹핑한다.
  * 리포트에서 슬라이드 위에 실제 찍힌 스티커를 재현할 때 사용.
  */
 const useRoomStickers = (roomId?: string | null) => {
-  const [stickers, setStickers] = useState<SlideSticker[]>([]);
-
-  useEffect(() => {
-    if (!roomId) {
-      setStickers([]);
-      return;
-    }
-
-    let cancelled = false;
-
-    getAllStickers(roomId)
-      .then((raw) => {
-        if (cancelled) return;
-        const normalized: SlideSticker[] = [];
-        (raw ?? []).forEach((item: any, index: number) => {
-          const emoji = Number(item?.emoji);
-          const slide = Number(item?.slide);
-          const xPct = Number(item?.x ?? item?.xPct);
-          const yPct = Number(item?.y ?? item?.yPct);
-          if (
-            !Number.isFinite(emoji) ||
-            !Number.isFinite(slide) ||
-            slide < 1 ||
-            !Number.isFinite(xPct) ||
-            !Number.isFinite(yPct)
-          ) {
-            return;
-          }
-          normalized.push({ id: `${emoji}-${slide}-${index}`, emoji, slide, xPct, yPct });
-        });
-        setStickers(normalized);
-      })
-      .catch((error) => {
-        if (!cancelled) {
-          log.error("스티커 좌표 로드 실패:", error);
-          setStickers([]);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [roomId]);
+  const { data } = useQuery({
+    ...roomStickersQuery(roomId ?? ""),
+    enabled: !!roomId,
+    select: normalizeStickers,
+  });
+  const stickers = useMemo(() => data ?? [], [data]);
 
   const stickersByEmojiSlide = useMemo(() => {
     const map = new Map<string, SlideSticker[]>();

--- a/src/pages/ai-report/ui/AiReportPage.tsx
+++ b/src/pages/ai-report/ui/AiReportPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useParams } from "react-router";
+import { useQuery } from "@tanstack/react-query";
 import { PageContainer, ContentContainer, FooterContainer } from "./AiReportPage.styles";
 import { SideHeader } from "./navigation";
 import {
@@ -12,7 +13,7 @@ import {
 } from "./sections";
 import FooterImage from "@/shared/assets/images/AI/AIFooter.png";
 import { loadStoredRoomData, computeRoomInfo } from "../model/room-info";
-import { fetchStoredAiReport, fetchMostRevisitSlide } from "@/shared/api/ai-report";
+import { storedAiReportQuery, mostRevisitSlideQuery } from "@/shared/api/ai-report";
 
 const AiReportPage = () => {
   const location = useLocation();
@@ -24,12 +25,6 @@ const AiReportPage = () => {
   const replaySlideRef = useRef<HTMLDivElement | null>(null);
   const reviewRef = useRef<HTMLDivElement | null>(null);
   const contentContainerRef = useRef<HTMLDivElement | null>(null);
-  const [storedReport, setStoredReport] = useState<any>(null);
-  const [reportLoading, setReportLoading] = useState(false);
-  const [reportError, setReportError] = useState<Error | null>(null);
-  const [revisitReport, setRevisitReport] = useState<any>(null);
-  const [revisitLoading, setRevisitLoading] = useState(false);
-  const [revisitError, setRevisitError] = useState<Error | null>(null);
   const [activeSection, setActiveSection] = useState("totalReaction");
 
   const storedRoomData = useMemo(() => loadStoredRoomData(), []);
@@ -43,81 +38,17 @@ const AiReportPage = () => {
   const roomId = roomIdParam || roomInfo.roomId;
   const { deckId, fileName } = roomInfo;
 
-  useEffect(() => {
-    let cancelled = false;
+  const reportQuery = useQuery({ ...storedAiReportQuery(roomId ?? ""), enabled: !!roomId });
+  const revisitQuery = useQuery({ ...mostRevisitSlideQuery(roomId ?? ""), enabled: !!roomId });
 
-    if (!roomId) {
-      setStoredReport(null);
-      setReportError(new Error("roomId를 확인할 수 없습니다."));
-      setReportLoading(false);
-      return undefined;
-    }
-
-    const loadReport = async () => {
-      setReportLoading(true);
-      setReportError(null);
-
-      try {
-        const data = await fetchStoredAiReport(roomId);
-        if (!cancelled) {
-          setStoredReport(data);
-        }
-      } catch (error) {
-        if (!cancelled) {
-          setStoredReport(null);
-          setReportError(error as Error);
-        }
-      } finally {
-        if (!cancelled) {
-          setReportLoading(false);
-        }
-      }
-    };
-
-    loadReport();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [roomId]);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    if (!roomId) {
-      setRevisitReport(null);
-      setRevisitError(new Error("roomId를 확인할 수 없습니다."));
-      setRevisitLoading(false);
-      return undefined;
-    }
-
-    const loadRevisit = async () => {
-      setRevisitLoading(true);
-      setRevisitError(null);
-
-      try {
-        const data = await fetchMostRevisitSlide(roomId);
-        if (!cancelled) {
-          setRevisitReport(data);
-        }
-      } catch (error) {
-        if (!cancelled) {
-          setRevisitReport(null);
-          setRevisitError(error as Error);
-        }
-      } finally {
-        if (!cancelled) {
-          setRevisitLoading(false);
-        }
-      }
-    };
-
-    loadRevisit();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [roomId]);
+  // roomId 부재는 쿼리 에러가 아니라 로컬 에러로 합성한다.
+  const missingRoomIdError = roomId ? null : new Error("roomId를 확인할 수 없습니다.");
+  const storedReport = reportQuery.data ?? null;
+  const reportLoading = reportQuery.isLoading;
+  const reportError = missingRoomIdError ?? reportQuery.error;
+  const revisitReport = revisitQuery.data ?? null;
+  const revisitLoading = revisitQuery.isLoading;
+  const revisitError = missingRoomIdError ?? revisitQuery.error;
 
   const scrollToSection = (sectionName: string) => {
     const refs: Record<string, React.RefObject<HTMLDivElement | null>> = {

--- a/src/pages/ai-report/ui/sections/PopularSlide/PopularSlide.tsx
+++ b/src/pages/ai-report/ui/sections/PopularSlide/PopularSlide.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useEffect, useMemo, useRef } from "react";
+import React, { useState, useMemo, useRef } from "react";
 import type { ComponentType, ReactNode, SyntheticEvent } from "react";
-import { createLogger } from "@/shared/lib/logger";
+import { useQuery } from "@tanstack/react-query";
 import {
   slideContentFractions,
   stampBoxStyle,
@@ -9,8 +9,6 @@ import {
 } from "@/shared/lib/slide-geometry";
 import type { SlideContentFractions } from "@/shared/lib/slide-geometry";
 import { useElementAspectRatio } from "@/shared/lib/use-element-aspect-ratio";
-
-const log = createLogger("ai-report");
 import {
   PopularSlideContainer,
   EmojiPanelWrapper,
@@ -25,7 +23,7 @@ import {
 import { EmojiPanel, SELECTED_EMOJI_ICONS } from "@/entities/reaction";
 import { ContentBox, AITitle, SlideNumber, SlideSkeleton } from "../../summary";
 import NoSlideImage from "@/shared/assets/images/AI/NoSlide.png";
-import { fetchMostReactionSticker } from "@/shared/api/ai-report";
+import { mostReactionStickerQuery } from "@/shared/api/ai-report";
 import { useSlideImage } from "@/entities/slide";
 import type { EmojiId } from "@/entities/reaction";
 import useRoomStickers from "../../../model/useRoomStickers";
@@ -97,32 +95,15 @@ const EMOJI_NAMES: Record<number, string> = {
 };
 
 const PopularSlide = ({ roomId, deckId }: { roomId?: any; deckId?: any }) => {
-  const [reactionData, setReactionData] = useState<ReactionSlideReportItem[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<any>(null);
   const [selectedEmojiId, setSelectedEmojiId] = useState(1); // 기본값: 재미있는 이모지
 
-  // API 호출
-  useEffect(() => {
-    if (!roomId) return;
-
-    const loadData = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const data = await fetchMostReactionSticker(roomId);
-        setReactionData(data || []);
-      } catch (err) {
-        log.error("이모지별 인기 슬라이드 데이터 로드 실패:", err);
-        setError(err);
-        setReactionData([]);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    loadData();
-  }, [roomId]);
+  const reactionQuery = useQuery({ ...mostReactionStickerQuery(roomId ?? ""), enabled: !!roomId });
+  const reactionData = useMemo(
+    () => (reactionQuery.data ?? []) as ReactionSlideReportItem[],
+    [reactionQuery.data]
+  );
+  const loading = reactionQuery.isLoading;
+  const error = reactionQuery.error;
 
   // 선택된 이모지의 데이터 찾기
   const selectedData = useMemo(() => {

--- a/src/pages/ai-report/ui/sections/QuestionSlide/QuestionSlide.tsx
+++ b/src/pages/ai-report/ui/sections/QuestionSlide/QuestionSlide.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo } from "react";
 import { useLocation } from "react-router";
+import { useQuery } from "@tanstack/react-query";
 import { createLogger } from "@/shared/lib/logger";
 
 const log = createLogger("ai-report");
@@ -13,7 +14,7 @@ import {
 import faceImage from "@/shared/assets/images/emoji1_black.svg";
 import rectangleImage from "@/shared/assets/images/AI/Rectangle.png";
 import { ContentBox, AITitle, SlideNumber } from "../../summary";
-import { fetchTopSlideReport } from "@/shared/api/ai-report";
+import { topSlideReportQuery } from "@/shared/api/ai-report";
 import { loadStoredRoomData, computeRoomInfo } from "../../../model/room-info";
 import { useSlideImage } from "@/entities/slide";
 
@@ -26,9 +27,6 @@ interface QuestionSlideReport {
 
 const QuestionSlide = () => {
   const location = useLocation();
-  const [report, setReport] = useState<QuestionSlideReport | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<any>(null);
 
   const storedRoomData = useMemo(() => loadStoredRoomData(), []);
 
@@ -39,58 +37,24 @@ const QuestionSlide = () => {
 
   const { roomId, deckId, totalPages } = roomInfo;
 
+  const reportQuery = useQuery({ ...topSlideReportQuery(roomId ?? "", true), enabled: !!roomId });
+  const report: QuestionSlideReport | null = reportQuery.data ?? null;
+  const loading = reportQuery.isLoading;
+  const error = roomId ? reportQuery.error : new Error("방 정보를 찾을 수 없습니다.");
+
   useEffect(() => {
-    let cancelled = false;
-
-    if (!roomId) {
-      setReport(null);
-      setError(new Error("방 정보를 찾을 수 없습니다."));
-      setLoading(false);
-      return undefined;
+    if (
+      report &&
+      totalPages &&
+      Number.isFinite(Number(report.slide)) &&
+      Number(report.slide) > Number(totalPages)
+    ) {
+      log.warn("보고된 슬라이드 번호가 총 페이지 수를 초과합니다:", {
+        slideNumber: report.slide,
+        totalPages,
+      });
     }
-
-    const loadReport = async () => {
-      setLoading(true);
-      setError(null);
-
-      try {
-        const result = await fetchTopSlideReport(roomId, {
-          latestFirst: true,
-        });
-
-        if (cancelled) return;
-
-        setReport(result);
-
-        if (
-          result &&
-          totalPages &&
-          Number.isFinite(Number(result.slide)) &&
-          Number(result.slide) > Number(totalPages)
-        ) {
-          log.warn("보고된 슬라이드 번호가 총 페이지 수를 초과합니다:", {
-            slideNumber: result.slide,
-            totalPages,
-          });
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setReport(null);
-          setError(err as any);
-        }
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      }
-    };
-
-    loadReport();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [roomId, totalPages]);
+  }, [report, totalPages]);
 
   const slideNumber =
     report && Number.isFinite(Number(report.slide)) && Number(report.slide) > 0

--- a/src/pages/ai-report/ui/sections/ReviewSlide/ReviewSlide.tsx
+++ b/src/pages/ai-report/ui/sections/ReviewSlide/ReviewSlide.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo } from "react";
 import { useLocation } from "react-router";
 import { useSetAtom } from "jotai";
+import { useQuery } from "@tanstack/react-query";
 import { audienceVoiceCsvEnabledAtom } from "@/entities/room";
-import { createLogger } from "@/shared/lib/logger";
 import {
   ReviewSlideContainer,
   TotalContainer,
@@ -24,15 +24,13 @@ import SatisfyImage from "@/shared/assets/images/AI/Satisfy.png";
 import StarImage from "@/shared/assets/images/AI/Star.png";
 import GrayFaceImage from "@/shared/assets/images/AI/reviewslide_face.png";
 import {
-  fetchFeedbackReport,
-  fetchAudienceVoiceReport,
+  audienceVoiceReportQuery,
+  feedbackReportQuery,
   type AudienceVoiceReport,
 } from "@/shared/api/ai-report";
 import { loadStoredRoomData, computeRoomInfo } from "../../../model/room-info";
 import { SatisfactionCard } from "./SatisfactionCard";
 import { QuestionVoiceCard } from "./QuestionVoiceCard";
-
-const log = createLogger("ai-report");
 
 interface FeedbackReport {
   averageRating?: number;
@@ -45,13 +43,6 @@ const POLL_INTERVAL_MS = 60 * 1000;
 
 const ReviewSlide = () => {
   const location = useLocation();
-  const [feedbackData, setFeedbackData] = useState<FeedbackReport | null>(null);
-  const [voiceData, setVoiceData] = useState<AudienceVoiceReport | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<unknown>(null);
-  const mountedRef = useRef(true);
-  const requestIdRef = useRef(0);
-  const pendingRequestsRef = useRef(0);
 
   const storedRoomData = useMemo(() => loadStoredRoomData(), []);
 
@@ -62,106 +53,34 @@ const ReviewSlide = () => {
 
   const { roomId } = roomInfo;
 
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
+  const voiceQuery = useQuery({
+    ...audienceVoiceReportQuery(roomId ?? ""),
+    enabled: !!roomId,
+    refetchInterval: POLL_INTERVAL_MS,
+  });
+  const voice = voiceQuery.data;
 
-  const loadFeedback = useCallback(
-    async (mode: "initial" | "poll") => {
-      if (!roomId) {
-        requestIdRef.current += 1;
-        setVoiceData(null);
-        setFeedbackData(null);
-        setError(new Error("roomId를 확인할 수 없습니다."));
-        setLoading(false);
-        return;
-      }
+  // 후기는 청중 질문이 없을 때만 조회하는 종속 쿼리다.
+  // isSuccess 대신 data 기준으로 게이트한다 — 폴링 한 번 실패해도(status 'error', data 유지)
+  // 후기 폴링이 멈추면 안 된다.
+  const feedbackQuery = useQuery({
+    ...feedbackReportQuery(roomId ?? ""),
+    enabled: voice !== undefined && !voice?.hasQuestions,
+    refetchInterval: POLL_INTERVAL_MS,
+  });
 
-      const requestId = requestIdRef.current + 1;
-      requestIdRef.current = requestId;
-      const canCommit = () => mountedRef.current && requestIdRef.current === requestId;
-      const isInitialLoad = mode === "initial";
-      pendingRequestsRef.current += 1;
+  const voiceData: AudienceVoiceReport | null = voice ?? null;
+  const feedbackData: FeedbackReport | null = feedbackQuery.data ?? null;
 
-      if (isInitialLoad) {
-        setLoading(true);
-      }
-
-      try {
-        const voice = await fetchAudienceVoiceReport(roomId);
-        if (canCommit()) {
-          setVoiceData(voice);
-          setError(null);
-        }
-
-        if (!voice || !voice.hasQuestions) {
-          try {
-            const data = await fetchFeedbackReport(roomId);
-            if (canCommit()) {
-              setFeedbackData(data);
-            }
-          } catch (feedbackErr) {
-            if (!canCommit()) {
-              return;
-            }
-            if (isInitialLoad) {
-              setFeedbackData(null);
-              setError(feedbackErr);
-            } else {
-              log.warn("후기 업데이트 실패 (기존 데이터 유지):", feedbackErr);
-            }
-          }
-        }
-      } catch (err) {
-        if (!canCommit()) {
-          return;
-        }
-        if (isInitialLoad) {
-          setVoiceData(null);
-          setError(err);
-        } else {
-          log.warn("청중의 목소리 업데이트 실패 (기존 데이터 유지):", err);
-        }
-      } finally {
-        pendingRequestsRef.current = Math.max(0, pendingRequestsRef.current - 1);
-        if (canCommit() && isInitialLoad) {
-          setLoading(false);
-        }
-      }
-    },
-    [roomId]
-  );
-
-  // 인터벌이 loadFeedback 정체성 변화로 재생성되지 않도록 ref로 최신 함수를 참조한다.
-  const loadFeedbackRef = useRef(loadFeedback);
-  useEffect(() => {
-    loadFeedbackRef.current = loadFeedback;
-  }, [loadFeedback]);
-
-  useEffect(() => {
-    if (!roomId) {
-      requestIdRef.current += 1;
-      setVoiceData(null);
-      setFeedbackData(null);
-      setError(new Error("roomId를 확인할 수 없습니다."));
-      setLoading(false);
-      return undefined;
-    }
-
-    loadFeedbackRef.current("initial");
-
-    // 60초마다 무조건 폴링한다. 오래된 응답은 requestId 가드로 무시되므로 중복 커밋은 없다.
-    const intervalId = window.setInterval(() => {
-      loadFeedbackRef.current("poll");
-    }, POLL_INTERVAL_MS);
-
-    return () => {
-      window.clearInterval(intervalId);
-    };
-  }, [roomId]);
+  // 폴링 실패는 error 를 세팅하되 이전 데이터를 유지하므로, UI 에러는 아직 데이터가 없는
+  // 초기 로드 실패에서만 켠다. (초기 로딩은 isLoading 으로 판단)
+  const loading = voiceQuery.isLoading || feedbackQuery.isLoading;
+  const error = useMemo(() => {
+    if (!roomId) return new Error("roomId를 확인할 수 없습니다.");
+    if (voiceQuery.error && voiceQuery.data === undefined) return voiceQuery.error;
+    if (feedbackQuery.error && feedbackQuery.data === undefined) return feedbackQuery.error;
+    return null;
+  }, [roomId, voiceQuery.error, voiceQuery.data, feedbackQuery.error, feedbackQuery.data]);
 
   const averageRating = useMemo(() => {
     if (loading || error) {

--- a/src/pages/ai-report/ui/sections/Top3/Top3.tsx
+++ b/src/pages/ai-report/ui/sections/Top3/Top3.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import { useLocation } from "react-router";
+import { useQuery } from "@tanstack/react-query";
 import {
   SectionContainer,
   HeaderRow,
@@ -25,12 +26,12 @@ import {
   EmptyState,
 } from "./Top3.styles";
 import { loadStoredRoomData, computeRoomInfo } from "../../../model/room-info";
+import { topQuestionsReportQuery } from "@/shared/api/ai-report";
 import {
-  fetchTopQuestionsReport,
-  fetchCompletedQuestions,
-  fetchUnansweredQuestions,
+  completedQuestionsQuery,
+  unansweredQuestionsQuery,
   type QuestionItemResponse,
-} from "@/shared/api/ai-report";
+} from "@/shared/api/question";
 
 type TabKey = "top3" | "answered" | "unanswered";
 
@@ -100,13 +101,6 @@ const getQuestionText = (item?: TopQuestionReportItem | null) => {
 const Top3 = () => {
   const location = useLocation();
   const [activeTab, setActiveTab] = useState<TabKey>("top3");
-  const [report, setReport] = useState<TopQuestionReport | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
-  const [answeredItems, setAnsweredItems] = useState<QuestionListItem[]>([]);
-  const [unansweredItems, setUnansweredItems] = useState<QuestionListItem[]>([]);
-  const [listLoading, setListLoading] = useState(false);
-  const [listError, setListError] = useState<Error | null>(null);
 
   const storedRoomData = useMemo(() => loadStoredRoomData(), []);
 
@@ -117,85 +111,29 @@ const Top3 = () => {
 
   const { roomId } = roomInfo;
 
-  useEffect(() => {
-    let cancelled = false;
+  const reportQuery = useQuery({ ...topQuestionsReportQuery(roomId ?? ""), enabled: !!roomId });
+  const report: TopQuestionReport | null = reportQuery.data ?? null;
+  const loading = reportQuery.isLoading;
+  const error = roomId ? reportQuery.error : new Error("방 정보를 찾을 수 없습니다.");
 
-    if (!roomId) {
-      setReport(null);
-      setError(new Error("방 정보를 찾을 수 없습니다."));
-      setLoading(false);
-      return undefined;
-    }
-
-    const loadReport = async () => {
-      setLoading(true);
-      setError(null);
-
-      try {
-        const result = await fetchTopQuestionsReport(roomId);
-        if (!cancelled) {
-          setReport(result);
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setReport(null);
-          setError(err as Error);
-        }
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      }
-    };
-
-    loadReport();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [roomId]);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    if (!roomId) {
-      setAnsweredItems([]);
-      setUnansweredItems([]);
-      setListError(new Error("방 정보를 찾을 수 없습니다."));
-      setListLoading(false);
-      return undefined;
-    }
-
-    const loadLists = async () => {
-      setListLoading(true);
-      setListError(null);
-
-      // * 두 목록은 독립적으로 처리해, 한쪽 실패가 다른 탭을 비우지 않도록 한다
-      const [completed, unanswered] = await Promise.allSettled([
-        fetchCompletedQuestions(roomId),
-        fetchUnansweredQuestions(roomId),
-      ]);
-
-      if (cancelled) return;
-
-      setAnsweredItems(completed.status === "fulfilled" ? toListItems(completed.value) : []);
-      setUnansweredItems(unanswered.status === "fulfilled" ? toListItems(unanswered.value) : []);
-
-      // * 두 요청이 모두 실패한 경우에만 에러 상태로 전환
-      if (completed.status === "rejected" && unanswered.status === "rejected") {
-        setListError(completed.reason as Error);
-      } else {
-        setListError(null);
-      }
-      setListLoading(false);
-    };
-
-    loadLists();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [roomId]);
+  // 두 목록은 독립 쿼리로, 한쪽 실패가 다른 탭을 비우지 않도록 한다.
+  const completedQuery = useQuery({
+    ...completedQuestionsQuery(roomId ?? ""),
+    enabled: !!roomId,
+    select: toListItems,
+  });
+  const unansweredQuery = useQuery({
+    ...unansweredQuestionsQuery(roomId ?? ""),
+    enabled: !!roomId,
+    select: toListItems,
+  });
+  const answeredItems = completedQuery.data ?? [];
+  const unansweredItems = unansweredQuery.data ?? [];
+  const listLoading = completedQuery.isLoading || unansweredQuery.isLoading;
+  // 두 요청이 모두 실패한 경우에만 에러 상태로 전환한다.
+  const listError = !roomId
+    ? new Error("방 정보를 찾을 수 없습니다.")
+    : (completedQuery.error && unansweredQuery.error) || null;
 
   const topItems = report?.top3 ?? [];
 

--- a/src/pages/presenter-room/model/question/usePresenterCompletedQuestions.ts
+++ b/src/pages/presenter-room/model/question/usePresenterCompletedQuestions.ts
@@ -1,9 +1,13 @@
-import { useState, useEffect, useCallback } from "react";
-import { fetchCompletedQuestions } from "@/shared/api/question";
+import { useCallback, useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { completedQuestionsQuery, type QuestionItemResponse } from "@/shared/api/question";
 import { normalizeQuestion, sortQuestionsAsc } from "@/entities/question";
 import type { NormalizedQuestion } from "@/entities/question";
 
 const isNormalizedQuestion = (q: NormalizedQuestion | null): q is NormalizedQuestion => q !== null;
+
+const selectCompleted = (list: QuestionItemResponse[]): NormalizedQuestion[] =>
+  sortQuestionsAsc(list.map(normalizeQuestion).filter(isNormalizedQuestion));
 
 const usePresenterCompletedQuestions = ({
   roomId,
@@ -12,45 +16,21 @@ const usePresenterCompletedQuestions = ({
   roomId?: string;
   enabled: boolean;
 }) => {
-  const [completedQuestions, setCompletedQuestions] = useState<NormalizedQuestion[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<unknown>(null);
-  const [refreshKey, setRefreshKey] = useState(0);
+  const { data, isLoading, error, refetch } = useQuery({
+    ...completedQuestionsQuery(roomId ?? ""),
+    enabled: !!roomId && enabled,
+    select: selectCompleted,
+    // 탭을 열 때마다 다시 가져온다 — 세션 중 완료 처리된 질문이 30초 캐시에 가려지면 안 된다.
+    staleTime: 0,
+  });
 
-  useEffect(() => {
-    if (!roomId || !enabled) {
-      setCompletedQuestions([]);
-      setLoading(false);
-      setError(null);
-      return;
-    }
+  const completedQuestions = useMemo(() => data ?? [], [data]);
 
-    let cancelled = false;
+  const reloadCompleted = useCallback(() => {
+    void refetch();
+  }, [refetch]);
 
-    setLoading(true);
-    setError(null);
-
-    fetchCompletedQuestions(roomId)
-      .then((list) => {
-        if (cancelled) return;
-        const normalized = list.map(normalizeQuestion).filter(isNormalizedQuestion);
-        setCompletedQuestions(sortQuestionsAsc(normalized));
-        setLoading(false);
-      })
-      .catch((err) => {
-        if (cancelled) return;
-        setError(err);
-        setLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [roomId, enabled, refreshKey]);
-
-  const reloadCompleted = useCallback(() => setRefreshKey((k) => k + 1), []);
-
-  return { completedQuestions, loading, error, reloadCompleted };
+  return { completedQuestions, loading: isLoading, error, reloadCompleted };
 };
 
 export default usePresenterCompletedQuestions;

--- a/src/pages/presenter-room/model/question/usePresenterQuestions.ts
+++ b/src/pages/presenter-room/model/question/usePresenterQuestions.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import websocketService from "@/shared/api/websocket";
 import { createLogger } from "@/shared/lib/logger";
 
@@ -7,6 +8,7 @@ import {
   fetchRoomQuestions,
   completeQuestion as apiComplete,
   deleteQuestion as apiDelete,
+  questionKeys,
 } from "@/shared/api/question";
 import {
   normalizeQuestion,
@@ -46,6 +48,7 @@ const usePresenterQuestions = ({
   enabled?: boolean;
   subscribe?: boolean;
 }) => {
+  const queryClient = useQueryClient();
   const [questions, setQuestions] = useState<NormalizedQuestion[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<unknown>(null);
@@ -113,11 +116,13 @@ const usePresenterQuestions = ({
       );
       try {
         await apiComplete(roomId, questionId);
+        // 완료 목록 캐시를 무효화해 완료 탭이 방금 완료된 질문을 놓치지 않게 한다.
+        void queryClient.invalidateQueries({ queryKey: questionKeys.completed(roomId) });
       } catch {
         // optimistic remove — no rollback
       }
     },
-    [roomId]
+    [roomId, queryClient]
   );
 
   const deleteQuestion = useCallback(

--- a/src/pages/rating/model/useAudienceFeedbackForm.ts
+++ b/src/pages/rating/model/useAudienceFeedbackForm.ts
@@ -1,36 +1,23 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { getFeedbackQuestions, type FeedbackQuestion } from "@/shared/api/feedback-questions";
+import { useCallback, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { feedbackQuestionsQuery, type FeedbackQuestion } from "@/shared/api/feedback-questions";
+
+const selectValidSorted = (questions: FeedbackQuestion[]): FeedbackQuestion[] =>
+  questions.filter((q) => typeof q.id === "number").sort((a, b) => a.orderIndex - b.orderIndex);
 
 export function useAudienceFeedbackForm(roomId: string | null) {
-  const [questions, setQuestions] = useState<FeedbackQuestion[]>([]);
   const [answers, setAnswers] = useState<Record<number, string>>({});
-  const [loading, setLoading] = useState<boolean>(Boolean(roomId));
-  const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!roomId) return;
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
-    getFeedbackQuestions(roomId)
-      .then((loaded) => {
-        if (cancelled) return;
-        const valid = loaded.filter((q) => typeof q.id === "number");
-        const sorted = [...valid].sort((a, b) => a.orderIndex - b.orderIndex);
-        setQuestions(sorted);
-      })
-      .catch(() => {
-        if (cancelled) return;
-        setError("질문을 불러오지 못했어요.");
-        setQuestions([]);
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [roomId]);
+  const { data, isLoading, isError } = useQuery({
+    ...feedbackQuestionsQuery(roomId ?? ""),
+    enabled: !!roomId,
+    select: selectValidSorted,
+    // 세션 종료 직후 청중 전원이 동시에 진입하는 경로 — 재시도로 요청을 배가시키지 않는다.
+    retry: false,
+  });
+
+  const questions = useMemo(() => data ?? [], [data]);
+  const error = isError ? "질문을 불러오지 못했어요." : null;
 
   const setAnswer = useCallback((questionId: number, value: string) => {
     setAnswers((prev) => ({ ...prev, [questionId]: value }));
@@ -56,7 +43,7 @@ export function useAudienceFeedbackForm(roomId: string | null) {
 
   return {
     questions,
-    loading,
+    loading: isLoading,
     error,
     answers,
     setAnswer,

--- a/src/pages/rating/model/useRatingPdfDownload.ts
+++ b/src/pages/rating/model/useRatingPdfDownload.ts
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import {
   downloadPdfSlides,
-  fetchPdfDownloadAvailability,
+  pdfDownloadAvailabilityQuery,
   type PdfDownloadAvailability,
 } from "@/shared/api/pdf-download";
 import { createLogger } from "@/shared/lib/logger";
@@ -26,59 +27,50 @@ const saveBlob = (blob: Blob, fileName: string) => {
 };
 
 export function useRatingPdfDownload({ roomId, audienceId, enabled }: UseRatingPdfDownloadParams) {
-  const [availability, setAvailability] = useState<PdfDownloadAvailability | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [downloading, setDownloading] = useState(false);
+  // Availability + download share one error field; last failure wins.
   const [error, setError] = useState<string | null>(null);
 
-  const refreshAvailability = useCallback(async () => {
-    if (!enabled || !roomId || !audienceId) {
-      setAvailability(null);
-      return null;
-    }
+  const { data, isLoading, refetch } = useQuery({
+    ...pdfDownloadAvailabilityQuery(roomId ?? "", audienceId ?? ""),
+    enabled: enabled && !!roomId && !!audienceId,
+    // 세션 종료 직후 청중 전원이 동시에 진입하는 경로 — 재시도로 요청을 배가시키지 않는다.
+    retry: false,
+  });
 
-    setLoading(true);
+  const availability = data ?? null;
+
+  const refreshAvailability = useCallback(async (): Promise<PdfDownloadAvailability | null> => {
     setError(null);
-    try {
-      const nextAvailability = await fetchPdfDownloadAvailability(roomId, audienceId);
-      setAvailability(nextAvailability);
-      return nextAvailability;
-    } catch (availabilityError) {
-      log.warn("Failed to fetch PDF download availability", availabilityError);
-      setAvailability(null);
+    const result = await refetch();
+    if (result.isError) {
+      log.warn("Failed to fetch PDF download availability", result.error);
       setError("다운로드 가능 여부를 확인하지 못했습니다.");
       return null;
-    } finally {
-      setLoading(false);
     }
-  }, [audienceId, enabled, roomId]);
+    return result.data ?? null;
+  }, [refetch]);
 
-  useEffect(() => {
-    void refreshAvailability();
-  }, [refreshAvailability]);
+  const { mutateAsync: runDownload, isPending: downloading } = useMutation({
+    mutationFn: (params: { roomId: string; audienceId: string }) =>
+      downloadPdfSlides(params.roomId, params.audienceId),
+    onError: (downloadError) => {
+      log.error("Failed to download PDF slides", downloadError);
+      setError("슬라이드 다운로드에 실패했습니다.");
+    },
+  });
 
   const downloadSlides = useCallback(async () => {
     if (!roomId || !audienceId) {
       throw new Error("roomId and audienceId are required");
     }
-
-    setDownloading(true);
     setError(null);
-    try {
-      const file = await downloadPdfSlides(roomId, audienceId);
-      saveBlob(file.blob, file.fileName ?? "boini-slides.pdf");
-    } catch (downloadError) {
-      log.error("Failed to download PDF slides", downloadError);
-      setError("슬라이드 다운로드에 실패했습니다.");
-      throw downloadError;
-    } finally {
-      setDownloading(false);
-    }
-  }, [audienceId, roomId]);
+    const file = await runDownload({ roomId, audienceId });
+    saveBlob(file.blob, file.fileName ?? "boini-slides.pdf");
+  }, [audienceId, roomId, runDownload]);
 
   return {
     availability,
-    loading,
+    loading: isLoading,
     downloading,
     error,
     refreshAvailability,

--- a/src/pages/rating/model/useRatingSubmission.ts
+++ b/src/pages/rating/model/useRatingSubmission.ts
@@ -1,6 +1,8 @@
 import { useCallback, useRef, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { submitFeedback } from "@/shared/api/feedback";
 import { submitFeedbackAnswers } from "@/shared/api/feedback-answers";
+import { pdfDownloadKeys } from "@/shared/api/pdf-download";
 import { markFeedbackSubmitted } from "./feedbackSubmissionMarker";
 
 export type SubmitPayload = {
@@ -10,14 +12,48 @@ export type SubmitPayload = {
   comment: string;
 };
 
+type SubmitContext = {
+  payload: SubmitPayload;
+  roomId: string;
+  audienceId: string;
+  audienceToken: string;
+};
+
 export function useRatingSubmission(
   roomId: string | null,
   audienceId: string | null,
   audienceToken: string | null
 ) {
-  const [submitting, setSubmitting] = useState(false);
+  const queryClient = useQueryClient();
   const [error, setError] = useState<string | null>(null);
+  // A retry after an answers failure must not re-submit the rating.
   const feedbackSubmitted = useRef(false);
+
+  const { mutateAsync, isPending: submitting } = useMutation({
+    mutationFn: async ({ payload, roomId, audienceId, audienceToken }: SubmitContext) => {
+      if (!feedbackSubmitted.current) {
+        await submitFeedback({
+          roomId,
+          audienceId,
+          audienceToken,
+          rating: payload.rating,
+          comment: payload.hasCustomQuestions ? "" : payload.comment,
+        });
+        feedbackSubmitted.current = true;
+      }
+      if (payload.hasCustomQuestions) {
+        await submitFeedbackAnswers(roomId, audienceId, audienceToken, payload.answers);
+      }
+      // Remember this identity submitted, so a later revisit can warn that
+      // re-submitting will overwrite the existing feedback.
+      markFeedbackSubmitted(roomId, audienceId);
+    },
+    onSuccess: (_data, { roomId, audienceId }) => {
+      queryClient.invalidateQueries({
+        queryKey: pdfDownloadKeys.availability(roomId, audienceId),
+      });
+    },
+  });
 
   const submit = useCallback(
     async (payload: SubmitPayload): Promise<boolean> => {
@@ -25,34 +61,16 @@ export function useRatingSubmission(
         setError("세션 정보를 찾을 수 없습니다.");
         return false;
       }
-      setSubmitting(true);
       setError(null);
       try {
-        if (!feedbackSubmitted.current) {
-          await submitFeedback({
-            roomId,
-            audienceId,
-            audienceToken,
-            rating: payload.rating,
-            comment: payload.hasCustomQuestions ? "" : payload.comment,
-          });
-          feedbackSubmitted.current = true;
-        }
-        if (payload.hasCustomQuestions) {
-          await submitFeedbackAnswers(roomId, audienceId, audienceToken, payload.answers);
-        }
-        // Remember this identity submitted, so a later revisit can warn that
-        // re-submitting will overwrite the existing feedback.
-        markFeedbackSubmitted(roomId, audienceId);
+        await mutateAsync({ payload, roomId, audienceId, audienceToken });
         return true;
       } catch {
         setError("제출에 실패했어요. 다시 시도해주세요.");
         return false;
-      } finally {
-        setSubmitting(false);
       }
     },
-    [roomId, audienceId, audienceToken]
+    [roomId, audienceId, audienceToken, mutateAsync]
   );
 
   return { submit, submitting, error };

--- a/src/pages/rating/ui/RatingPage.tsx
+++ b/src/pages/rating/ui/RatingPage.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useMemo, useEffect } from "react";
+import React, { useState, useMemo } from "react";
 import { useParams, useNavigate, useLocation } from "react-router";
+import { useQuery } from "@tanstack/react-query";
 import styled from "styled-components";
 import { MEDIA } from "@/shared/config/breakpoints";
 import { createLogger } from "@/shared/lib/logger";
@@ -8,7 +9,7 @@ const log = createLogger("rating");
 import Emoji3 from "@/shared/assets/images/emoji3.svg";
 import StarIcon from "@/shared/assets/images/star.svg";
 import StarCheckedIcon from "@/shared/assets/images/star_checked.svg";
-import { getOriginalSlideUrl } from "@/shared/api/presentation";
+import { slideImageQuery } from "@/shared/api/presentation";
 import { resolveRatingSessionContext } from "../model/resolveRatingSessionContext";
 import { hasSubmittedFeedback } from "../model/feedbackSubmissionMarker";
 import { Skeleton } from "@/shared/ui/skeleton";
@@ -26,8 +27,6 @@ const RatingPage = () => {
   const [rating, setRating] = useState(0);
   const [comment, setComment] = useState("");
   const [popoverDismissed, setPopoverDismissed] = useState(false);
-  const [firstSlideUrl, setFirstSlideUrl] = useState<string | null>(null);
-  const [loadingSlide, setLoadingSlide] = useState(false);
   const [identityWarningDismissed, setIdentityWarningDismissed] = useState(false);
 
   const clearAudienceSession = () => {
@@ -72,22 +71,12 @@ const RatingPage = () => {
   const isComplete = rating > 0 && (hasCustomQuestions ? allAnswered : comment.trim().length > 0);
 
   // 첫 번째 슬라이드 로드
-  useEffect(() => {
-    if (!roomId || !deckId) return;
-    const loadFirstSlide = async () => {
-      setLoadingSlide(true);
-      try {
-        const url = await getOriginalSlideUrl(roomId, deckId, 1);
-        setFirstSlideUrl(url);
-      } catch (error) {
-        log.error("첫 번째 슬라이드 로드 실패:", error);
-        setFirstSlideUrl(null);
-      } finally {
-        setLoadingSlide(false);
-      }
-    };
-    loadFirstSlide();
-  }, [roomId, deckId]);
+  const { data: firstSlideUrl, isLoading: loadingSlide } = useQuery({
+    ...slideImageQuery(roomId ?? "", deckId ?? "", 1),
+    enabled: Boolean(roomId && deckId),
+    // 세션 종료 직후 청중 전원이 동시에 진입하는 경로 — 재시도로 요청을 배가시키지 않는다.
+    retry: false,
+  });
 
   const buildPayload = () => ({
     rating,

--- a/src/shared/api/ai-report.ts
+++ b/src/shared/api/ai-report.ts
@@ -1,3 +1,4 @@
+import { queryOptions } from "@tanstack/react-query";
 import aiApi from "./ai-api";
 import api from "./api";
 import { createLogger } from "@/shared/lib/logger";
@@ -17,30 +18,6 @@ export async function fetchTopQuestionsReport(roomId: string) {
   if (!roomId) throw new Error("roomId is required");
   const response = await aiApi.get(`/report/questions/rooms/${roomId}/top3`);
   return response?.data?.data ?? null;
-}
-
-// * 청중 질문 관리 API 응답 단건 (Spring 백엔드 CreateQuestionResponse)
-export interface QuestionItemResponse {
-  id: string;
-  roomId: string;
-  slide: number;
-  audienceId: string;
-  content: string;
-  ts: number;
-}
-
-// * 답변 완료 처리된 질문 목록 (ts 오름차순)
-export async function fetchCompletedQuestions(roomId: string): Promise<QuestionItemResponse[]> {
-  if (!roomId) throw new Error("roomId is required");
-  const response = await api.get(`/api/questions/rooms/${roomId}/completed`);
-  return response?.data?.data ?? [];
-}
-
-// * 미답변(활성) 질문 목록 - 백엔드 목록 조회는 completed/deleted를 제외하므로 미답변과 동일
-export async function fetchUnansweredQuestions(roomId: string): Promise<QuestionItemResponse[]> {
-  if (!roomId) throw new Error("roomId is required");
-  const response = await api.get(`/api/questions/rooms/${roomId}`);
-  return response?.data?.data ?? [];
 }
 
 export async function fetchMostRevisitSlide(roomId: string) {
@@ -146,4 +123,64 @@ export async function downloadAudienceVoiceCsv(
   anchor.click();
   anchor.remove();
   setTimeout(() => window.URL.revokeObjectURL(url), 0);
+}
+
+export const aiReportKeys = {
+  stored: (roomId: string) => ["ai-report", roomId, "stored"] as const,
+  mostRevisit: (roomId: string) => ["ai-report", roomId, "most-revisit"] as const,
+  topSlide: (roomId: string, latestFirst?: boolean) =>
+    ["ai-report", roomId, "top-slide", latestFirst ?? null] as const,
+  topQuestions: (roomId: string) => ["ai-report", roomId, "top-questions"] as const,
+  reactionSticker: (roomId: string) => ["ai-report", roomId, "reaction-sticker"] as const,
+  feedback: (roomId: string) => ["ai-report", roomId, "feedback"] as const,
+  audienceVoice: (roomId: string) => ["ai-report", roomId, "audience-voice"] as const,
+};
+
+export function storedAiReportQuery(roomId: string) {
+  return queryOptions({
+    queryKey: aiReportKeys.stored(roomId),
+    queryFn: () => fetchStoredAiReport(roomId),
+  });
+}
+
+export function mostRevisitSlideQuery(roomId: string) {
+  return queryOptions({
+    queryKey: aiReportKeys.mostRevisit(roomId),
+    queryFn: () => fetchMostRevisitSlide(roomId),
+  });
+}
+
+export function topSlideReportQuery(roomId: string, latestFirst?: boolean) {
+  return queryOptions({
+    queryKey: aiReportKeys.topSlide(roomId, latestFirst),
+    queryFn: () => fetchTopSlideReport(roomId, { latestFirst }),
+  });
+}
+
+export function topQuestionsReportQuery(roomId: string) {
+  return queryOptions({
+    queryKey: aiReportKeys.topQuestions(roomId),
+    queryFn: () => fetchTopQuestionsReport(roomId),
+  });
+}
+
+export function mostReactionStickerQuery(roomId: string) {
+  return queryOptions({
+    queryKey: aiReportKeys.reactionSticker(roomId),
+    queryFn: () => fetchMostReactionSticker(roomId),
+  });
+}
+
+export function feedbackReportQuery(roomId: string) {
+  return queryOptions({
+    queryKey: aiReportKeys.feedback(roomId),
+    queryFn: () => fetchFeedbackReport(roomId),
+  });
+}
+
+export function audienceVoiceReportQuery(roomId: string) {
+  return queryOptions({
+    queryKey: aiReportKeys.audienceVoice(roomId),
+    queryFn: () => fetchAudienceVoiceReport(roomId),
+  });
 }

--- a/src/shared/api/feedback-questions.ts
+++ b/src/shared/api/feedback-questions.ts
@@ -1,3 +1,4 @@
+import { queryOptions } from "@tanstack/react-query";
 import api from "./api";
 import { createLogger } from "@/shared/lib/logger";
 
@@ -34,4 +35,15 @@ export async function saveFeedbackQuestions(
     log.error("Failed to save feedback questions", error);
     throw error;
   }
+}
+
+export const feedbackQuestionsKeys = {
+  all: (roomId: string) => ["feedback-questions", roomId] as const,
+};
+
+export function feedbackQuestionsQuery(roomId: string) {
+  return queryOptions({
+    queryKey: feedbackQuestionsKeys.all(roomId),
+    queryFn: () => getFeedbackQuestions(roomId),
+  });
 }

--- a/src/shared/api/pdf-download.ts
+++ b/src/shared/api/pdf-download.ts
@@ -1,3 +1,4 @@
+import { queryOptions } from "@tanstack/react-query";
 import api from "./api";
 
 export interface PdfDownloadAvailability {
@@ -69,4 +70,16 @@ export async function downloadPdfSlides(
     blob: response.data,
     fileName: fileName ? decodeURIComponent(fileName) : null,
   };
+}
+
+export const pdfDownloadKeys = {
+  availability: (roomId: string, audienceId: string) =>
+    ["pdf-download-availability", roomId, audienceId] as const,
+};
+
+export function pdfDownloadAvailabilityQuery(roomId: string, audienceId: string) {
+  return queryOptions({
+    queryKey: pdfDownloadKeys.availability(roomId, audienceId),
+    queryFn: () => fetchPdfDownloadAvailability(roomId, audienceId),
+  });
 }

--- a/src/shared/api/presentation.ts
+++ b/src/shared/api/presentation.ts
@@ -1,3 +1,4 @@
+import { queryOptions } from "@tanstack/react-query";
 import api from "./api";
 import type { AudienceStats } from "@/entities/slide";
 
@@ -217,4 +218,44 @@ export async function fetchLiveFeedback({
     if (error?.response?.status === 404) return null;
     throw error;
   }
+}
+
+export const presentationKeys = {
+  slides: (roomId: string, deckId: string, totalPages: number) =>
+    ["slides", roomId, deckId, totalPages] as const,
+  slideImage: (roomId: string, deckId: string, page: number) =>
+    ["slide-image", roomId, deckId, page] as const,
+  // presenterToken 은 queryFn 의 Authorization 에 쓰이므로 키에도 포함해야
+  // 토큰 재발급 시 이전 자격으로 받은 캐시가 재사용되지 않는다.
+  slideNotes: (roomId: string, deckId: string, presenterToken: string) =>
+    ["slide-notes", roomId, deckId, presenterToken] as const,
+};
+
+export function slideUrlsQuery(roomId: string, deckId: string, totalPages: number) {
+  return queryOptions({
+    queryKey: presentationKeys.slides(roomId, deckId, totalPages),
+    queryFn: () => fetchAllOriginalSlideUrls(roomId, deckId, totalPages),
+  });
+}
+
+export function slideImageQuery(roomId: string, deckId: string, page: number) {
+  return queryOptions({
+    queryKey: presentationKeys.slideImage(roomId, deckId, page),
+    queryFn: () => getOriginalSlideUrl(roomId, deckId, page),
+  });
+}
+
+export function slideNotesQuery({
+  roomId,
+  deckId,
+  presenterToken,
+}: {
+  roomId: string;
+  deckId: string;
+  presenterToken: string;
+}) {
+  return queryOptions({
+    queryKey: presentationKeys.slideNotes(roomId, deckId, presenterToken),
+    queryFn: ({ signal }) => fetchSlideNotes({ roomId, deckId, presenterToken, signal }),
+  });
 }

--- a/src/shared/api/question.ts
+++ b/src/shared/api/question.ts
@@ -1,7 +1,18 @@
+import { queryOptions } from "@tanstack/react-query";
 import api from "./api";
 import type { QuestionCluster } from "@/entities/question";
 import websocketService from "./websocket";
 import { v4 as uuidv4 } from "uuid";
+
+// * 청중 질문 관리 API 응답 단건 (Spring 백엔드 CreateQuestionResponse)
+export interface QuestionItemResponse {
+  id: string;
+  roomId: string;
+  slide: number;
+  audienceId: string;
+  content: string;
+  ts: number;
+}
 
 interface FetchQuestionsOptions {
   fromTs?: number;
@@ -39,10 +50,18 @@ export async function deleteQuestion(roomId: string, questionId: string): Promis
   await api.patch(`/api/questions/${roomId}/${questionId}/delete`);
 }
 
-export async function fetchCompletedQuestions(roomId: string) {
+// * 답변 완료 처리된 질문 목록 (ts 오름차순)
+export async function fetchCompletedQuestions(roomId: string): Promise<QuestionItemResponse[]> {
   if (!roomId) throw new Error("roomId is required");
   const response = await api.get(`/api/questions/rooms/${roomId}/completed`);
   return Array.isArray(response?.data?.data) ? response.data.data : [];
+}
+
+// * 미답변(활성) 질문 목록 - 백엔드 목록 조회는 completed/deleted를 제외하므로 미답변과 동일
+export async function fetchUnansweredQuestions(roomId: string): Promise<QuestionItemResponse[]> {
+  if (!roomId) throw new Error("roomId is required");
+  const response = await api.get(`/api/questions/rooms/${roomId}`);
+  return response?.data?.data ?? [];
 }
 
 export async function fetchCurrentClusters(roomId: string): Promise<QuestionCluster[]> {
@@ -76,4 +95,24 @@ export function sendQuestionLike({
     },
     { "Idempotency-Key": uuidv4() }
   );
+}
+
+// 프레젠터 룸과 AI 리포트 페이지가 같은 캐시 엔트리를 공유하도록 키를 통일한다.
+export const questionKeys = {
+  completed: (roomId: string) => ["questions", roomId, "completed"] as const,
+  unanswered: (roomId: string) => ["questions", roomId, "unanswered"] as const,
+};
+
+export function completedQuestionsQuery(roomId: string) {
+  return queryOptions({
+    queryKey: questionKeys.completed(roomId),
+    queryFn: () => fetchCompletedQuestions(roomId),
+  });
+}
+
+export function unansweredQuestionsQuery(roomId: string) {
+  return queryOptions({
+    queryKey: questionKeys.unanswered(roomId),
+    queryFn: () => fetchUnansweredQuestions(roomId),
+  });
 }

--- a/src/shared/api/sticker.ts
+++ b/src/shared/api/sticker.ts
@@ -1,3 +1,4 @@
+import { queryOptions } from "@tanstack/react-query";
 import api from "./api";
 import { createLogger } from "@/shared/lib/logger";
 
@@ -23,4 +24,15 @@ export async function getStickersByAudience(sessionId: string, audienceId: strin
     log.error("Failed to fetch audience stickers", error);
     return [];
   }
+}
+
+export const stickerKeys = {
+  all: (roomId: string) => ["stickers", roomId] as const,
+};
+
+export function roomStickersQuery(roomId: string) {
+  return queryOptions({
+    queryKey: stickerKeys.all(roomId),
+    queryFn: () => getAllStickers(roomId),
+  });
 }

--- a/src/widgets/app-header/model/feedback/useFeedbackQuestionGuard.ts
+++ b/src/widgets/app-header/model/feedback/useFeedbackQuestionGuard.ts
@@ -1,35 +1,23 @@
-import { useCallback, useEffect, useState } from "react";
-import { getFeedbackQuestions } from "@/shared/api/feedback-questions";
+import { useQuery } from "@tanstack/react-query";
+import { feedbackQuestionsQuery, type FeedbackQuestion } from "@/shared/api/feedback-questions";
+
+const selectHasQuestions = (questions: FeedbackQuestion[]): boolean => questions.length > 0;
 
 /**
  * * 발표 준비 중인 방의 후기 질문 존재 여부를 미리 조회한다.
  * 세션 시작 시 질문이 하나도 없으면 경고 모달을 띄우기 위한 가드.
  * hasQuestions: null = 확인 전 또는 조회 실패(세션 시작을 막지 않도록 fail-open),
  * true·false = 확정된 결과.
+ * 질문 저장(useFeedbackQuestions.save)이 캐시를 무효화하므로 별도 refresh 는 필요 없다.
  */
 export const useFeedbackQuestionGuard = (roomId: string | undefined, enabled: boolean) => {
-  const [hasQuestions, setHasQuestions] = useState<boolean | null>(null);
+  const { data, isSuccess } = useQuery({
+    ...feedbackQuestionsQuery(roomId ?? ""),
+    enabled: enabled && !!roomId,
+    select: selectHasQuestions,
+  });
 
-  const refresh = useCallback(async () => {
-    if (!roomId) {
-      setHasQuestions(null);
-      return;
-    }
-    try {
-      const questions = await getFeedbackQuestions(roomId);
-      setHasQuestions(questions.length > 0);
-    } catch {
-      setHasQuestions(null);
-    }
-  }, [roomId]);
+  const hasQuestions: boolean | null = isSuccess ? (data ?? null) : null;
 
-  useEffect(() => {
-    if (!enabled || !roomId) {
-      setHasQuestions(null);
-      return;
-    }
-    refresh();
-  }, [enabled, roomId, refresh]);
-
-  return { hasQuestions, refresh };
+  return { hasQuestions };
 };

--- a/src/widgets/app-header/model/room/index.ts
+++ b/src/widgets/app-header/model/room/index.ts
@@ -1,2 +1,3 @@
 export { useHeaderRoomData } from "./useHeaderRoomData";
 export { resolveShareJoinUrl } from "./resolveShareJoinUrl";
+export { useShareRoomInit } from "./useShareRoomInit";

--- a/src/widgets/app-header/model/room/useShareRoomInit.ts
+++ b/src/widgets/app-header/model/room/useShareRoomInit.ts
@@ -1,0 +1,60 @@
+import { useEffect, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { createRoom } from "@/shared/api/room";
+import { createLogger } from "@/shared/lib/logger";
+import { resolveShareJoinUrl } from "./resolveShareJoinUrl";
+
+const log = createLogger("share");
+
+/**
+ * 공유 모달의 세션 링크 준비: roomData 가 있으면 joinUrl 만 해석하고,
+ * 없으면(랜딩에서 바로 공유) 방을 새로 만들어 링크를 얻는다.
+ */
+export const useShareRoomInit = ({
+  roomData,
+  totalPages,
+}: {
+  roomData?: Parameters<typeof resolveShareJoinUrl>[0];
+  totalPages: number;
+}) => {
+  const [sessionLink, setSessionLink] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const { mutateAsync: createRoomAsync } = useMutation({
+    mutationFn: (pages: number) => createRoom(pages),
+  });
+
+  useEffect(() => {
+    if (roomData) {
+      const resolvedJoinUrl = resolveShareJoinUrl(roomData);
+      if (!resolvedJoinUrl) {
+        setError("공유 링크를 생성할 수 없습니다.");
+      } else {
+        setSessionLink(resolvedJoinUrl);
+        setError("");
+      }
+      setLoading(false);
+      return;
+    }
+
+    const initRoom = async () => {
+      try {
+        const data = await createRoomAsync(totalPages);
+        const resolvedJoinUrl = resolveShareJoinUrl(data);
+        if (!resolvedJoinUrl) {
+          throw new Error("joinUrl resolve failed");
+        }
+        setSessionLink(resolvedJoinUrl);
+      } catch (err) {
+        log.error("방 생성 실패:", err);
+        setError("방 생성 중 오류가 발생했습니다.");
+      } finally {
+        setLoading(false);
+      }
+    };
+    initRoom();
+  }, [roomData, totalPages, createRoomAsync]);
+
+  return { sessionLink, loading, error };
+};

--- a/src/widgets/app-header/model/session/useHeaderSessionAction.ts
+++ b/src/widgets/app-header/model/session/useHeaderSessionAction.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useLocation, useNavigate } from "react-router";
 import { useSetAtom } from "jotai";
 import { presenterModeAtom } from "@/entities/room";
@@ -6,9 +7,9 @@ import { startSession, closeSession } from "@/shared/api/room";
 import { sessionStartMarker } from "@/shared/config/storage-keys";
 import { SESSION_BEFORE_START_EVENT } from "@/shared/config/session-events";
 import {
-  fetchTopSlideReport,
-  fetchTopQuestionsReport,
   fetchTopStoredReport,
+  topSlideReportQuery,
+  topQuestionsReportQuery,
 } from "@/shared/api/ai-report";
 import websocketService from "@/shared/api/websocket";
 import { createLogger } from "@/shared/lib/logger";
@@ -44,16 +45,53 @@ export const useHeaderSessionAction = ({
 }: UseHeaderSessionActionParams) => {
   const location = useLocation();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const setPresenterMode = useSetAtom(presenterModeAtom);
 
-  const [isSessionEnding, setIsSessionEnding] = useState(false);
   const [showLandingPage, setShowLandingPage] = useState(false);
   const [landingMessage, setLandingMessage] = useState("AI 리포트 생성 중 ...");
+
+  const { mutateAsync: startSessionAsync } = useMutation({
+    mutationFn: (startRoomId: string) => startSession(startRoomId),
+  });
+
+  const { mutateAsync: endSessionAsync, isPending: isSessionEnding } = useMutation({
+    mutationFn: async (endRoomId: string) => {
+      // ! Send WS end-session notification before API call
+      if (websocketService.getIsConnected()) {
+        try {
+          websocketService.sendEndSession(endRoomId);
+          log.log("세션 종료 웹소켓 알림 전송 완료:", endRoomId);
+        } catch (wsError) {
+          log.warn("웹소켓 알림 전송 실패 (계속 진행):", wsError);
+        }
+      } else {
+        log.warn("WebSocket이 연결되지 않아 알림을 전송할 수 없습니다.");
+      }
+
+      // * Warm up AI report data; the two consumed reports land in the query cache
+      // * so the report page renders instantly. fetchQuery (not prefetchQuery) so
+      // * failures reject and stay visible to the allSettled warn log below.
+      const reportResults = await Promise.allSettled([
+        fetchTopStoredReport(endRoomId),
+        queryClient.fetchQuery(topSlideReportQuery(endRoomId, true)),
+        queryClient.fetchQuery(topQuestionsReportQuery(endRoomId)),
+      ]);
+
+      const reportErrors = reportResults.filter((r) => r.status === "rejected");
+      if (reportErrors.length > 0) {
+        log.warn("레포트 선행 호출 중 일부 실패:", reportErrors);
+      }
+
+      await closeSession(endRoomId);
+      sessionStartMarker.clear(endRoomId);
+      log.log("세션 종료 API(DELETE) 성공:", endRoomId);
+    },
+  });
 
   useEffect(() => {
     if (location.pathname.endsWith("/report")) {
       setShowLandingPage(false);
-      setIsSessionEnding(false);
     }
   }, [location.pathname]);
 
@@ -73,7 +111,7 @@ export const useHeaderSessionAction = ({
 
       try {
         await flushBeforeSessionStart();
-        await startSession(roomData.roomId);
+        await startSessionAsync(roomData.roomId);
         // 새로고침 시에도 발표 화면으로 복원되도록 시작 마커를 저장.
         sessionStartMarker.set(roomData.roomId);
         // 단일 경로이므로 라우팅하지 않고 모드만 발표로 전환한다.
@@ -97,39 +135,12 @@ export const useHeaderSessionAction = ({
         return;
       }
 
-      setIsSessionEnding(true);
       setLandingMessage("AI 리포트 생성 중 ...");
       setShowLandingPage(true);
       let didNavigate = false;
 
       try {
-        // ! Send WS end-session notification before API call
-        if (websocketService.getIsConnected()) {
-          try {
-            websocketService.sendEndSession(resolvedRoomId);
-            log.log("세션 종료 웹소켓 알림 전송 완료:", resolvedRoomId);
-          } catch (wsError) {
-            log.warn("웹소켓 알림 전송 실패 (계속 진행):", wsError);
-          }
-        } else {
-          log.warn("WebSocket이 연결되지 않아 알림을 전송할 수 없습니다.");
-        }
-
-        // * Pre-fetch AI report data
-        const reportResults = await Promise.allSettled([
-          fetchTopStoredReport(resolvedRoomId),
-          fetchTopSlideReport(resolvedRoomId, { latestFirst: true }),
-          fetchTopQuestionsReport(resolvedRoomId),
-        ]);
-
-        const reportErrors = reportResults.filter((r) => r.status === "rejected");
-        if (reportErrors.length > 0) {
-          log.warn("레포트 선행 호출 중 일부 실패:", reportErrors);
-        }
-
-        await closeSession(resolvedRoomId);
-        sessionStartMarker.clear(resolvedRoomId);
-        log.log("세션 종료 API(DELETE) 성공:", resolvedRoomId);
+        await endSessionAsync(resolvedRoomId);
 
         const nextState = {
           roomId: resolvedRoomId,
@@ -162,7 +173,6 @@ export const useHeaderSessionAction = ({
         alert("⚠️ 세션 종료 처리에 실패했습니다. 다시 시도해주세요.");
         setShowLandingPage(false);
       } finally {
-        setIsSessionEnding(false);
         if (!didNavigate) {
           setShowLandingPage(false);
         }
@@ -179,6 +189,8 @@ export const useHeaderSessionAction = ({
     navigate,
     location.state,
     setPresenterMode,
+    startSessionAsync,
+    endSessionAsync,
   ]);
 
   return {

--- a/src/widgets/app-header/ui/header/AppHeader.tsx
+++ b/src/widgets/app-header/ui/header/AppHeader.tsx
@@ -139,8 +139,7 @@ function AppHeader({ roomData: propRoomData, totalPages }: AppHeaderProps) {
   const csvEnabled = useAtomValue(audienceVoiceCsvEnabledAtom);
 
   // 준비 화면에서 후기 질문 존재 여부를 미리 조회해 세션 시작 시 경고 판단에 사용.
-  const { hasQuestions: hasFeedbackQuestions, refresh: refreshFeedbackQuestions } =
-    useFeedbackQuestionGuard(roomData?.roomId, isPrep);
+  const { hasQuestions: hasFeedbackQuestions } = useFeedbackQuestionGuard(roomData?.roomId, isPrep);
 
   const { isSessionEnding, showLandingPage, landingMessage, handleSessionAction } =
     useHeaderSessionAction({
@@ -236,9 +235,9 @@ function AppHeader({ roomData: propRoomData, totalPages }: AppHeaderProps) {
     setShowPresenterStartWarning(true);
   };
 
+  // 저장(save)이 feedback-questions 캐시를 무효화하므로 닫을 때 별도 재조회는 불필요.
   const handleFeedbackQuestionModalClose = () => {
     setShowFeedbackQuestionModal(false);
-    refreshFeedbackQuestions();
   };
 
   const handleExitClick = async () => {

--- a/src/widgets/app-header/ui/share/ShareModal.tsx
+++ b/src/widgets/app-header/ui/share/ShareModal.tsx
@@ -1,12 +1,8 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import styled from "styled-components";
 import { QRCodeSVG } from "qrcode.react";
 import CopyIcon from "@/shared/assets/images/copy.svg";
-import { createRoom } from "@/shared/api/room";
-import { createLogger } from "@/shared/lib/logger";
-import { resolveShareJoinUrl } from "../../model";
-
-const log = createLogger("share");
+import { useShareRoomInit } from "../../model";
 
 const Overlay = styled.div`
   position: fixed;
@@ -144,40 +140,7 @@ interface ShareModalProps {
 }
 
 const ShareModal = ({ roomData, totalPages = 10, onClose }: ShareModalProps) => {
-  const [sessionLink, setSessionLink] = useState("");
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState("");
-
-  useEffect(() => {
-    if (roomData) {
-      const resolvedJoinUrl = resolveShareJoinUrl(roomData);
-      if (!resolvedJoinUrl) {
-        setError("공유 링크를 생성할 수 없습니다.");
-      } else {
-        setSessionLink(resolvedJoinUrl);
-        setError("");
-      }
-      setLoading(false);
-      return;
-    }
-
-    const initRoom = async () => {
-      try {
-        const data = await createRoom(totalPages);
-        const resolvedJoinUrl = resolveShareJoinUrl(data);
-        if (!resolvedJoinUrl) {
-          throw new Error("joinUrl resolve failed");
-        }
-        setSessionLink(resolvedJoinUrl);
-      } catch (err) {
-        log.error("방 생성 실패:", err);
-        setError("방 생성 중 오류가 발생했습니다.");
-      } finally {
-        setLoading(false);
-      }
-    };
-    initRoom();
-  }, [roomData, totalPages]);
+  const { sessionLink, loading, error } = useShareRoomInit({ roomData, totalPages });
 
   const handleCopy = () => {
     if (!sessionLink) return;

--- a/tests/unit/use-feedback-questions.test.ts
+++ b/tests/unit/use-feedback-questions.test.ts
@@ -1,13 +1,30 @@
+import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const { getFeedbackQuestions, saveFeedbackQuestions } = vi.hoisted(() => ({
   getFeedbackQuestions: vi.fn(),
   saveFeedbackQuestions: vi.fn(),
 }));
-vi.mock("@/shared/api/feedback-questions", () => ({ getFeedbackQuestions, saveFeedbackQuestions }));
+// Factory/keys are built on top of the mocked fns so the hook's queryFn hits the mock.
+vi.mock("@/shared/api/feedback-questions", () => ({
+  getFeedbackQuestions,
+  saveFeedbackQuestions,
+  feedbackQuestionsKeys: { all: (roomId: string) => ["feedback-questions", roomId] },
+  feedbackQuestionsQuery: (roomId: string) => ({
+    queryKey: ["feedback-questions", roomId],
+    queryFn: () => getFeedbackQuestions(roomId),
+  }),
+}));
 
 import { useFeedbackQuestions } from "@/features/feedback-questions/model/useFeedbackQuestions";
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
 
 describe("useFeedbackQuestions", () => {
   beforeEach(() => {
@@ -17,7 +34,9 @@ describe("useFeedbackQuestions", () => {
 
   it("pads loaded questions to a minimum of 6 rows", async () => {
     getFeedbackQuestions.mockResolvedValue([{ id: 1, orderIndex: 0, questionText: "q1" }]);
-    const { result } = renderHook(() => useFeedbackQuestions("room1", true));
+    const { result } = renderHook(() => useFeedbackQuestions("room1", true), {
+      wrapper: createWrapper(),
+    });
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.rows).toHaveLength(6);
     expect(result.current.rows[0]).toBe("q1");
@@ -26,7 +45,9 @@ describe("useFeedbackQuestions", () => {
 
   it("caps adding at 20 rows", async () => {
     getFeedbackQuestions.mockResolvedValue([]);
-    const { result } = renderHook(() => useFeedbackQuestions("room1", true));
+    const { result } = renderHook(() => useFeedbackQuestions("room1", true), {
+      wrapper: createWrapper(),
+    });
     await waitFor(() => expect(result.current.loading).toBe(false));
     for (let i = 0; i < 20; i++) act(() => result.current.addRow());
     expect(result.current.rows).toHaveLength(20);
@@ -36,7 +57,9 @@ describe("useFeedbackQuestions", () => {
   it("drops blank rows and re-indexes on save", async () => {
     getFeedbackQuestions.mockResolvedValue([]);
     saveFeedbackQuestions.mockResolvedValue([]);
-    const { result } = renderHook(() => useFeedbackQuestions("room1", true));
+    const { result } = renderHook(() => useFeedbackQuestions("room1", true), {
+      wrapper: createWrapper(),
+    });
     await waitFor(() => expect(result.current.loading).toBe(false));
     act(() => result.current.setRow(0, "first"));
     act(() => result.current.setRow(2, "third"));


### PR DESCRIPTION
## 개요

서버 상태(fetching/캐싱)를 수제 `useState`+`useEffect`+`AbortController` 패턴에서 **TanStack Query v5** 로 마이그레이션합니다. (Phase 1–3 범위)

## 주요 변경

- **셋업**: `@tanstack/react-query` 도입, `src/app/query-client.ts` (retry 1 · staleTime 30s · focus refetch off — 청중 다수 접속 환경에서 refetch 폭주 방지), Playwright CT 하네스에 Provider 래핑
- **쿼리 팩토리**: 각 도메인의 axios 함수 옆에 `queryOptions` + 키 팩토리 co-locate (`src/shared/api/*.ts`, FSD 가이드의 shared-by-controller 방식). 소비자는 `enabled`/`select`/정책 오버라이드만 적용
- **읽기 마이그레이션**: AI 리포트 페이지·전 섹션(60초 폴링 → `refetchInterval`), 슬라이드 URL/이미지/노트, 스티커, 후기 질문(발표자 편집기·청중 폼·헤더 가드가 캐시 공유), 완료 질문, PDF 다운로드 가능 여부
- **뮤테이션 마이그레이션**: 세션 시작/종료(종료 시 리포트 캐시 워밍 → 리포트 페이지 즉시 렌더), 평가 제출(+가능 여부 캐시 무효화), 후기 질문 저장, PDF 정책(낙관적 업데이트+롤백), 방 생성(ShareModal → model 훅 이동)
- **중복 제거**: `fetchCompletedQuestions` 이중 정의 제거, 발표자 룸·리포트가 단일 캐시 엔트리 공유

## 코드 리뷰 후속 수정 (8건 반영)

- 슬라이드 노트 저장 시 캐시 write-through + 리시드 시 디바운스 중 편집 보존 (준비→발표 전환에서 노트 유실 방지)
- 질문 완료 시 완료 목록 캐시 무효화 + 완료 탭 `staleTime: 0`
- `slide-notes` 쿼리 키에 `presenterToken` 포함
- ReviewSlide 종속 쿼리를 `isSuccess` 대신 data 기준으로 게이트 (폴링 1회 실패로 후기 폴링 중단 방지)
- 리포트 워밍업을 `fetchQuery` 로 전환해 실패 로그 복원
- 세션 종료 직후 청중 폭주 경로 쿼리에 `retry: false`
- 후기 질문 모달 닫을 때 중복 GET 제거

## 범위 제외 (의도적)

REST+WebSocket 하이브리드 훅(질문 피드·통계·실시간 피드백·클러스터), 청중 join 플로우, PresenterRoomGate, 업로드/SSE 오케스트레이션은 이번 브랜치에서 변경하지 않음 (Phase 4 후보).

## 검증

- `pnpm typecheck` ✅ · `pnpm lint` 0 errors(경고는 기존 180개 그대로) · `pnpm build` ✅
- 유닛 테스트 32 pass / 3 fail — 3건은 HEAD(dev)에서도 동일하게 실패하는 기존 실패로 확인(임시 worktree 재현)
- 환경 변수/배포 설정 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)