### PR TITLE
✨ feat(session-create): PPTX 누락 폰트 업로드 모달 및 폰트 적용 변환 플로우

### DIFF
--- a/src/pages/session-create/model/useChunkedPdfUpload.ts
+++ b/src/pages/session-create/model/useChunkedPdfUpload.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import type { ChunkUploadReady } from '@/shared/api/model/pdf';
+import type { ChunkUploadTerminal } from '@/shared/api/model/pdf';
 import { uploadPdfInChunks } from '@/shared/api/pdfUpload';
 
 interface UploadProgress {
@@ -12,7 +12,7 @@ interface UploadProgress {
 export function useChunkedPdfUpload() {
   const [progress, setProgress] = useState<UploadProgress>({ sent: 0, total: 0 });
   const [error, setError] = useState<Error | null>(null);
-  const [result, setResult] = useState<ChunkUploadReady | null>(null);
+  const [result, setResult] = useState<ChunkUploadTerminal | null>(null);
   const [isUploading, setIsUploading] = useState(false);
 
   const upload = useCallback(
@@ -21,20 +21,20 @@ export function useChunkedPdfUpload() {
       roomId: string,
       deckId: string,
       signal?: AbortSignal,
-    ): Promise<ChunkUploadReady> => {
+    ): Promise<ChunkUploadTerminal> => {
       setError(null);
       setResult(null);
       setProgress({ sent: 0, total: 0 });
       setIsUploading(true);
       try {
-        const ready = await uploadPdfInChunks(file, {
+        const terminal = await uploadPdfInChunks(file, {
           roomId,
           deckId,
           signal,
           onProgress: setProgress,
         });
-        setResult(ready);
-        return ready;
+        setResult(terminal);
+        return terminal;
       } catch (e) {
         const err = e instanceof Error ? e : new Error(String(e));
         setError(err);

--- a/src/pages/session-create/model/useFontMutations.ts
+++ b/src/pages/session-create/model/useFontMutations.ts
@@ -1,0 +1,40 @@
+import { useMutation } from "@tanstack/react-query";
+import { finalizeUpload, uploadFonts } from "@/shared/api/pdfFonts";
+import type { ChunkUploadReady, FontUploadResponse } from "@/shared/api/model/pdf";
+
+interface Params {
+  onUploaded: (fontName: string, res: FontUploadResponse) => void;
+  onUploadError: () => void;
+  onFinalized: (ready: ChunkUploadReady) => void;
+  onFinalizeError: () => void;
+}
+
+/**
+ * 개별 폰트 업로드 / 변환 시작(finalize)을 React Query mutation 으로 래핑한다.
+ * (청크 업로드는 병렬 전송 로직이라 raw axios 그대로 둔다.)
+ */
+export function useFontMutations({ onUploaded, onUploadError, onFinalized, onFinalizeError }: Params) {
+  const uploadMutation = useMutation({
+    mutationFn: (v: { uploadId: string; fontName: string; file: File }) =>
+      uploadFonts(v.uploadId, [v.file], v.fontName),
+    onSuccess: (res, v) => onUploaded(v.fontName, res),
+    onError: onUploadError,
+  });
+
+  const finalizeMutation = useMutation({
+    mutationFn: (v: { uploadId: string; proceedWithoutFonts: boolean }) =>
+      finalizeUpload(v.uploadId, v.proceedWithoutFonts),
+    onSuccess: onFinalized,
+    onError: onFinalizeError,
+  });
+
+  return {
+    uploadFont: (uploadId: string, fontName: string, file: File) =>
+      uploadMutation.mutate({ uploadId, fontName, file }),
+    finalize: (uploadId: string, proceedWithoutFonts: boolean) =>
+      finalizeMutation.mutate({ uploadId, proceedWithoutFonts }),
+    // 업로드 진행 중인 폰트명(진행 중일 때만), 그리고 변환(finalize) 진행 여부
+    uploadingName: uploadMutation.isPending ? uploadMutation.variables?.fontName ?? null : null,
+    busy: finalizeMutation.isPending,
+  };
+}

--- a/src/pages/session-create/ui/FontRequirementPrompt.styles.ts
+++ b/src/pages/session-create/ui/FontRequirementPrompt.styles.ts
@@ -144,60 +144,48 @@ export const StatusChip = styled.span<{ $missing: boolean }>`
   background: ${({ $missing }) => ($missing ? "#fdeee7" : "#eaf6ec")};
 `;
 
-export const Picker = styled.div`
+export const RowRight = styled.div`
+  flex: 0 0 auto;
   display: flex;
-  flex-direction: column;
+  align-items: center;
   gap: 8px;
-  inline-size: 100%;
+`;
+
+export const UploadButton = styled.button`
+  min-block-size: 28px;
+  padding: 4px 10px;
+  border: 1px solid #303030;
+  border-radius: 3px;
+  background: #fff;
+  color: #303030;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: -0.025em;
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    background: #303030;
+    color: #fff;
+  }
+
+  &:disabled {
+    border-color: #dcdcdc;
+    color: #b8b8b8;
+    cursor: not-allowed;
+  }
 `;
 
 export const HiddenInput = styled.input`
   display: none;
 `;
 
-export const PickButton = styled.button`
-  min-block-size: 40px;
-  padding: 10px 12px;
-  border: 1px dashed #cfcfcf;
-  border-radius: 10px;
-  background: #fafafa;
-  color: #303030;
-  font-size: 13px;
-  font-weight: 500;
-  letter-spacing: -0.025em;
-  cursor: pointer;
-  transition: border-color 0.15s, background 0.15s;
-
-  &:hover {
-    border-color: #e74d07;
-    background: #fff7f3;
-  }
-`;
-
-export const PickHint = styled.p`
+export const Hint = styled.p`
   margin: 0;
   color: #8a8a8a;
   font-size: 12px;
   letter-spacing: -0.02em;
   text-align: center;
-`;
-
-export const RecheckButton = styled.button`
-  min-block-size: 36px;
-  padding: 8px 12px;
-  border: 1px solid #eaeaea;
-  border-radius: 3px;
-  background: #fff;
-  color: #303030;
-  font-size: 13px;
-  font-weight: 500;
-  letter-spacing: -0.025em;
-  cursor: pointer;
-
-  &:disabled {
-    color: #b8b8b8;
-    cursor: not-allowed;
-  }
 `;
 
 export const ErrorText = styled.p`

--- a/src/pages/session-create/ui/FontRequirementPrompt.styles.ts
+++ b/src/pages/session-create/ui/FontRequirementPrompt.styles.ts
@@ -89,6 +89,44 @@ export const Description = styled.p`
   }
 `;
 
+// 업로드 가능한 파일 조건(형식/용량)을 보여주는 간단한 스펙 표.
+export const SpecTable = styled.table`
+  inline-size: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  border: 1px solid #eaeaea;
+  border-radius: 10px;
+  overflow: hidden;
+  font-size: 12px;
+  letter-spacing: -0.02em;
+
+  th,
+  td {
+    padding: 8px 12px;
+    text-align: start;
+    vertical-align: middle;
+  }
+
+  tr:not(:last-child) th,
+  tr:not(:last-child) td {
+    border-block-end: 1px solid #f2f2f2;
+  }
+`;
+
+export const SpecLabel = styled.th`
+  inline-size: 92px;
+  color: #8a8a8a;
+  font-weight: 500;
+  white-space: nowrap;
+  background: #fafafa;
+  border-inline-end: 1px solid #f2f2f2;
+`;
+
+export const SpecValue = styled.td`
+  color: #303030;
+  font-weight: 500;
+`;
+
 export const Resolved = styled.p`
   margin: 0;
   color: #1a7f37;
@@ -123,10 +161,10 @@ export const FontList = styled.ul`
   border: 1px solid #eaeaea;
   border-radius: 10px;
   max-block-size: 264px;
-  overflow-y: auto;
+  overflow-y: scroll; /* 항상 얇은 스크롤바를 노출한다(overflow 시에만 뜨지 않도록). */
   overscroll-behavior: contain;
 
-  /* 디자인 시스템에 맞춘 얇은 스크롤바 */
+  /* 디자인 시스템에 맞춘 얇은 스크롤바 (항상 표시) */
   scrollbar-width: thin;
   scrollbar-color: #d9d9d9 transparent;
 
@@ -140,6 +178,7 @@ export const FontList = styled.ul`
   }
   &::-webkit-scrollbar-track {
     background: transparent;
+    margin-block: 4px;
   }
 `;
 

--- a/src/pages/session-create/ui/FontRequirementPrompt.styles.ts
+++ b/src/pages/session-create/ui/FontRequirementPrompt.styles.ts
@@ -93,7 +93,25 @@ export const FontList = styled.ul`
   inline-size: 100%;
   border: 1px solid #eaeaea;
   border-radius: 10px;
-  overflow: hidden;
+  max-block-size: 264px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+
+  /* 디자인 시스템에 맞춘 얇은 스크롤바 */
+  scrollbar-width: thin;
+  scrollbar-color: #d9d9d9 transparent;
+
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: #d9d9d9;
+    border-radius: 999px;
+    border: 2px solid #fff;
+  }
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
 `;
 
 export const FontRow = styled.li`
@@ -102,9 +120,14 @@ export const FontRow = styled.li`
   gap: 4px;
   padding: 10px 14px;
   border-block-end: 1px solid #f2f2f2;
+  transition: background 0.12s;
 
   &:last-child {
     border-block-end: 0;
+  }
+
+  &:hover {
+    background: #fafafa;
   }
 `;
 
@@ -117,6 +140,13 @@ export const FontRowMain = styled.div`
 
 export const SubstituteNote = styled.span`
   color: #8a8a8a;
+  font-size: 12px;
+  letter-spacing: -0.02em;
+  word-break: break-word;
+`;
+
+export const WarningNote = styled.span`
+  color: #c23c0a;
   font-size: 12px;
   letter-spacing: -0.02em;
   word-break: break-word;

--- a/src/pages/session-create/ui/FontRequirementPrompt.styles.ts
+++ b/src/pages/session-create/ui/FontRequirementPrompt.styles.ts
@@ -98,15 +98,28 @@ export const FontList = styled.ul`
 
 export const FontRow = styled.li`
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+  flex-direction: column;
+  gap: 4px;
   padding: 10px 14px;
   border-block-end: 1px solid #f2f2f2;
 
   &:last-child {
     border-block-end: 0;
   }
+`;
+
+export const FontRowMain = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+`;
+
+export const SubstituteNote = styled.span`
+  color: #8a8a8a;
+  font-size: 12px;
+  letter-spacing: -0.02em;
+  word-break: break-word;
 `;
 
 export const FontName = styled.span`

--- a/src/pages/session-create/ui/FontRequirementPrompt.styles.ts
+++ b/src/pages/session-create/ui/FontRequirementPrompt.styles.ts
@@ -12,6 +12,18 @@ export const Overlay = styled.div`
   background: rgba(0, 0, 0, 0.6);
 `;
 
+// 확인 모달은 폰트 모달(Overlay, z-index 10000) 위에 뜬다.
+export const ConfirmOverlay = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 10001;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.45);
+`;
+
 export const Dialog = styled.div`
   inline-size: min(440px, 100%);
   max-block-size: min(88vh, 760px);
@@ -84,6 +96,23 @@ export const Resolved = styled.p`
   font-weight: 500;
   line-height: 1.45;
   letter-spacing: -0.025em;
+`;
+
+export const ListWrap = styled.div`
+  position: relative;
+  inline-size: 100%;
+`;
+
+// 목록이 넘칠 때 하단에 살짝 겹쳐, 더 스크롤할 내용이 있음을 알리는 그라데이션.
+export const ScrollFade = styled.div`
+  position: absolute;
+  inset-inline: 1px;
+  inset-block-end: 1px;
+  block-size: 44px;
+  border-end-start-radius: 10px;
+  border-end-end-radius: 10px;
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0), #fff);
+  pointer-events: none;
 `;
 
 export const FontList = styled.ul`

--- a/src/pages/session-create/ui/FontRequirementPrompt.styles.ts
+++ b/src/pages/session-create/ui/FontRequirementPrompt.styles.ts
@@ -1,0 +1,248 @@
+import styled from "styled-components";
+
+// 슬라이드 로딩 화면(SessionLoadingOverlay, z-index 9999) 위에 뜨도록 그보다 높게 둔다.
+export const Overlay = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.6);
+`;
+
+export const Dialog = styled.div`
+  inline-size: min(440px, 100%);
+  max-block-size: min(88vh, 760px);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  border-radius: 16px;
+  background: #fff;
+`;
+
+export const Content = styled.div`
+  flex: 1 1 auto;
+  min-block-size: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 32px 32px 0;
+`;
+
+export const Body = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+`;
+
+export const Mascot = styled.img`
+  inline-size: min(72px, 24vw);
+  block-size: auto;
+  display: block;
+`;
+
+export const TextGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  inline-size: 100%;
+  text-align: center;
+  word-break: keep-all;
+`;
+
+export const Title = styled.h2`
+  margin: 0;
+  color: #111;
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 1.4;
+  letter-spacing: -0.025em;
+`;
+
+export const Description = styled.p`
+  margin: 0;
+  color: #505050;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.45;
+  letter-spacing: -0.025em;
+
+  b {
+    color: #e74d07;
+    font-weight: 600;
+  }
+`;
+
+export const Resolved = styled.p`
+  margin: 0;
+  color: #1a7f37;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.45;
+  letter-spacing: -0.025em;
+`;
+
+export const FontList = styled.ul`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  inline-size: 100%;
+  border: 1px solid #eaeaea;
+  border-radius: 10px;
+  overflow: hidden;
+`;
+
+export const FontRow = styled.li`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 14px;
+  border-block-end: 1px solid #f2f2f2;
+
+  &:last-child {
+    border-block-end: 0;
+  }
+`;
+
+export const FontName = styled.span`
+  color: #303030;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -0.025em;
+  word-break: break-word;
+`;
+
+export const StatusChip = styled.span<{ $missing: boolean }>`
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 9px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  white-space: nowrap;
+  color: ${({ $missing }) => ($missing ? "#c23c0a" : "#1a7f37")};
+  background: ${({ $missing }) => ($missing ? "#fdeee7" : "#eaf6ec")};
+`;
+
+export const Picker = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  inline-size: 100%;
+`;
+
+export const HiddenInput = styled.input`
+  display: none;
+`;
+
+export const PickButton = styled.button`
+  min-block-size: 40px;
+  padding: 10px 12px;
+  border: 1px dashed #cfcfcf;
+  border-radius: 10px;
+  background: #fafafa;
+  color: #303030;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -0.025em;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+
+  &:hover {
+    border-color: #e74d07;
+    background: #fff7f3;
+  }
+`;
+
+export const PickHint = styled.p`
+  margin: 0;
+  color: #8a8a8a;
+  font-size: 12px;
+  letter-spacing: -0.02em;
+  text-align: center;
+`;
+
+export const RecheckButton = styled.button`
+  min-block-size: 36px;
+  padding: 8px 12px;
+  border: 1px solid #eaeaea;
+  border-radius: 3px;
+  background: #fff;
+  color: #303030;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -0.025em;
+  cursor: pointer;
+
+  &:disabled {
+    color: #b8b8b8;
+    cursor: not-allowed;
+  }
+`;
+
+export const ErrorText = styled.p`
+  margin: 0;
+  color: #e74d07;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -0.025em;
+  text-align: center;
+`;
+
+export const Footer = styled.div`
+  flex: 0 0 auto;
+  display: flex;
+  gap: 8px;
+  padding: 20px 32px 32px;
+  background: #fff;
+
+  > button {
+    flex: 1 1 0;
+    min-inline-size: 0;
+  }
+`;
+
+export const ConfirmButton = styled.button`
+  min-block-size: 40px;
+  padding: 8px 12px;
+  border: 0;
+  border-radius: 3px;
+  background: #303030;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.45;
+  letter-spacing: -0.025em;
+  cursor: pointer;
+
+  &:disabled {
+    background: #c9c9c9;
+    cursor: not-allowed;
+  }
+`;
+
+export const SecondaryButton = styled.button`
+  min-block-size: 40px;
+  padding: 8px 12px;
+  border: 1px solid #eaeaea;
+  border-radius: 3px;
+  background: #fff;
+  color: #303030;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.45;
+  letter-spacing: -0.025em;
+  cursor: pointer;
+
+  &:disabled {
+    color: #b8b8b8;
+    cursor: not-allowed;
+  }
+`;

--- a/src/pages/session-create/ui/FontRequirementPrompt.tsx
+++ b/src/pages/session-create/ui/FontRequirementPrompt.tsx
@@ -25,12 +25,14 @@ import {
   TextGroup,
   Title,
   UploadButton,
+  WarningNote,
 } from "./FontRequirementPrompt.styles";
 
 interface Props {
   fontReport: FontReportEntry[];
   busy: boolean; // 변환(finalize) 진행 중
   uploadingName: string | null; // 현재 업로드 중인 폰트명
+  warnings: Record<string, string>; // 폰트명 → 방금 올렸지만 이름이 다른 폰트의 패밀리명
   error: string | null;
   onUploadFont: (fontName: string, file: File) => void;
   onContinue: () => void;
@@ -41,6 +43,7 @@ export default function FontRequirementPrompt({
   fontReport,
   busy,
   uploadingName,
+  warnings,
   error,
   onUploadFont,
   onContinue,
@@ -104,7 +107,14 @@ export default function FontRequirementPrompt({
                       )}
                     </RowRight>
                   </FontRowMain>
-                  {missing && f.substitute && <SubstituteNote>대체 글꼴: {f.substitute}</SubstituteNote>}
+                  {missing && warnings[f.name] !== undefined ? (
+                    <WarningNote>
+                      업로드한 파일이 이 폰트와 달라요
+                      {warnings[f.name] ? ` (올린 폰트: ${warnings[f.name]})` : ""}.
+                    </WarningNote>
+                  ) : (
+                    missing && f.substitute && <SubstituteNote>대체 글꼴: {f.substitute}</SubstituteNote>
+                  )}
                 </FontRow>
               );
             })}

--- a/src/pages/session-create/ui/FontRequirementPrompt.tsx
+++ b/src/pages/session-create/ui/FontRequirementPrompt.tsx
@@ -1,0 +1,60 @@
+import { useRef, useState } from "react";
+import type { FontReportEntry } from "@/shared/api/model/pdf";
+
+interface Props {
+  fontReport: FontReportEntry[];
+  busy: boolean;
+  error: string | null;
+  onUploadFonts: (files: File[]) => void;
+  onProceedWithout: () => void;
+}
+
+export default function FontRequirementPrompt({
+  fontReport,
+  busy,
+  error,
+  onUploadFonts,
+  onProceedWithout,
+}: Props) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [picked, setPicked] = useState<File[]>([]);
+  const missingCount = fontReport.filter((f) => f.status === "MISSING").length;
+
+  return (
+    <div role="dialog" aria-label="폰트 업로드" style={{ maxWidth: 560, margin: "10vh auto", padding: 24 }}>
+      <h2>이 발표 자료에 필요한 폰트가 서버에 없어요</h2>
+      <p>
+        정확한 글꼴로 변환하려면 아래 <b>{missingCount}</b>개의 폰트를 업로드하세요.
+      </p>
+      <ul>
+        {fontReport.map((f) => (
+          <li key={f.name}>
+            <span>{f.name}</span>{" "}
+            <span aria-label={f.status}>{f.status === "MISSING" ? "❌ 없음" : "✅ 사용 가능"}</span>
+          </li>
+        ))}
+      </ul>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".ttf,.otf,.ttc"
+        multiple
+        onChange={(e) => setPicked(Array.from(e.target.files ?? []))}
+      />
+      {picked.length > 0 && <p>{picked.length}개 선택됨</p>}
+      {error && (
+        <p role="alert" style={{ color: "#e8541e" }}>
+          {error}
+        </p>
+      )}
+      <div style={{ display: "flex", gap: 8, marginTop: 16 }}>
+        <button type="button" disabled={busy || picked.length === 0} onClick={() => onUploadFonts(picked)}>
+          이 폰트로 계속
+        </button>
+        <button type="button" disabled={busy} onClick={onProceedWithout}>
+          그냥 진행
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/session-create/ui/FontRequirementPrompt.tsx
+++ b/src/pages/session-create/ui/FontRequirementPrompt.tsx
@@ -14,7 +14,6 @@ import {
   FontName,
   FontRow,
   FontRowMain,
-  Hint,
   HiddenInput,
   ListWrap,
   Mascot,
@@ -23,6 +22,9 @@ import {
   RowRight,
   ScrollFade,
   SecondaryButton,
+  SpecLabel,
+  SpecTable,
+  SpecValue,
   StatusChip,
   SubstituteNote,
   TextGroup,
@@ -106,12 +108,29 @@ export default function FontRequirementPrompt({
                   <Resolved>필요한 폰트가 모두 준비되었어요.</Resolved>
                 ) : (
                   <Description>
-                    정확한 폰트로 변환하려면 각 폰트 오른쪽의 <b>업로드</b>를 눌러 파일을 올려주세요. 올리지
-                    않은 폰트는 대체 글꼴로 대체돼요.
+                    PPT를 원본 그대로 가져오려면 아래 목록에서 오른쪽의 <b>업로드</b>를 눌러 필요한
+                    폰트 파일을 올려주세요.
+                    <br />
+                    올리지 않은 폰트는 비슷한 글꼴로 대체돼요.
                   </Description>
                 )}
               </TextGroup>
             </Body>
+
+            {!allResolved && (
+              <SpecTable aria-label="업로드 가능한 폰트 파일 조건">
+                <tbody>
+                  <tr>
+                    <SpecLabel scope="row">파일 형식</SpecLabel>
+                    <SpecValue>.ttf, .otf, .ttc</SpecValue>
+                  </tr>
+                  <tr>
+                    <SpecLabel scope="row">최대 용량</SpecLabel>
+                    <SpecValue>파일당 15MB, 전체 60MB</SpecValue>
+                  </tr>
+                </tbody>
+              </SpecTable>
+            )}
 
             <ListWrap>
               <FontList ref={listRef} onScroll={syncFade} aria-label="필요한 폰트 목록">
@@ -123,11 +142,18 @@ export default function FontRequirementPrompt({
                       <FontRowMain>
                         <FontName>{f.name}</FontName>
                         <RowRight>
-                          <StatusChip $missing={missing} aria-label={missing ? "없음" : "사용 가능"}>
+                          <StatusChip
+                            $missing={missing}
+                            aria-label={missing ? "없음" : "사용 가능"}
+                          >
                             {missing ? "없음" : "사용 가능"}
                           </StatusChip>
                           {missing && (
-                            <UploadButton type="button" disabled={anyBusy} onClick={() => openPicker(f.name)}>
+                            <UploadButton
+                              type="button"
+                              disabled={anyBusy}
+                              onClick={() => openPicker(f.name)}
+                            >
                               {isUploading ? "업로드 중…" : "업로드"}
                             </UploadButton>
                           )}
@@ -139,7 +165,8 @@ export default function FontRequirementPrompt({
                           {warnings[f.name] ? ` (올린 폰트: ${warnings[f.name]})` : ""}.
                         </WarningNote>
                       ) : (
-                        missing && f.substitute && <SubstituteNote>대체 글꼴: {f.substitute}</SubstituteNote>
+                        missing &&
+                        f.substitute && <SubstituteNote>대체 글꼴: {f.substitute}</SubstituteNote>
                       )}
                     </FontRow>
                   );
@@ -147,19 +174,23 @@ export default function FontRequirementPrompt({
               </FontList>
               {showFade && <ScrollFade aria-hidden="true" />}
             </ListWrap>
-            <Hint>.ttf · .otf · .ttc · 최대 15MB</Hint>
 
-            <HiddenInput ref={inputRef} type="file" accept=".ttf,.otf,.ttc" onChange={handleFileChange} />
+            <HiddenInput
+              ref={inputRef}
+              type="file"
+              accept=".ttf,.otf,.ttc"
+              onChange={handleFileChange}
+            />
 
             {error && <ErrorText role="alert">{error}</ErrorText>}
           </Content>
 
           <Footer>
             <SecondaryButton type="button" disabled={anyBusy} onClick={onProceedWithout}>
-              그냥 진행
+              건너뛰기
             </SecondaryButton>
             <ConfirmButton type="button" disabled={anyBusy} onClick={handleContinueClick}>
-              변환 시작
+              진행하기
             </ConfirmButton>
           </Footer>
         </Dialog>
@@ -173,15 +204,16 @@ export default function FontRequirementPrompt({
                 <TextGroup>
                   <Title id="font-confirm-title">아직 준비되지 않은 폰트가 있어요</Title>
                   <Description>
-                    남은 <b>{missingCount}</b>개의 폰트는 서버의 대체 글꼴로 대체돼요. 그래도 변환을
-                    시작할까요?
+                    남은 <b>{missingCount}</b>개의 폰트는 비슷한 글꼴로 대체돼요.
+                    <br />
+                    그래도 계속 진행할까요?
                   </Description>
                 </TextGroup>
               </Body>
             </Content>
             <Footer>
               <SecondaryButton type="button" onClick={() => setConfirmOpen(false)}>
-                취소
+                취소하기
               </SecondaryButton>
               <ConfirmButton
                 type="button"
@@ -190,7 +222,7 @@ export default function FontRequirementPrompt({
                   onContinue();
                 }}
               >
-                네, 시작할게요
+                네, 진행할게요.
               </ConfirmButton>
             </Footer>
           </Dialog>

--- a/src/pages/session-create/ui/FontRequirementPrompt.tsx
+++ b/src/pages/session-create/ui/FontRequirementPrompt.tsx
@@ -5,6 +5,7 @@ interface Props {
   fontReport: FontReportEntry[];
   busy: boolean;
   error: string | null;
+  onCheckFonts: (files: File[]) => void;
   onUploadFonts: (files: File[]) => void;
   onProceedWithout: () => void;
 }
@@ -13,19 +14,25 @@ export default function FontRequirementPrompt({
   fontReport,
   busy,
   error,
+  onCheckFonts,
   onUploadFonts,
   onProceedWithout,
 }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [picked, setPicked] = useState<File[]>([]);
   const missingCount = fontReport.filter((f) => f.status === "MISSING").length;
+  const allResolved = missingCount === 0;
 
   return (
     <div role="dialog" aria-label="폰트 업로드" style={{ maxWidth: 560, margin: "10vh auto", padding: 24 }}>
       <h2>이 발표 자료에 필요한 폰트가 서버에 없어요</h2>
-      <p>
-        정확한 글꼴로 변환하려면 아래 <b>{missingCount}</b>개의 폰트를 업로드하세요.
-      </p>
+      {allResolved ? (
+        <p style={{ color: "#1a7f37" }}>✅ 모든 폰트가 준비되었어요. 계속 진행하세요.</p>
+      ) : (
+        <p>
+          정확한 글꼴로 변환하려면 아래 <b>{missingCount}</b>개의 폰트를 업로드하세요.
+        </p>
+      )}
       <ul>
         {fontReport.map((f) => (
           <li key={f.name}>
@@ -42,6 +49,13 @@ export default function FontRequirementPrompt({
         onChange={(e) => setPicked(Array.from(e.target.files ?? []))}
       />
       {picked.length > 0 && <p>{picked.length}개 선택됨</p>}
+      <button
+        type="button"
+        disabled={busy || picked.length === 0}
+        onClick={() => onCheckFonts(picked)}
+      >
+        선택한 폰트로 다시 확인
+      </button>
       {error && (
         <p role="alert" style={{ color: "#e8541e" }}>
           {error}

--- a/src/pages/session-create/ui/FontRequirementPrompt.tsx
+++ b/src/pages/session-create/ui/FontRequirementPrompt.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useRef, type ChangeEvent } from "react";
 import type { FontReportEntry } from "@/shared/api/model/pdf";
 import FontMascot from "@/shared/assets/images/session-warning-face.svg";
 import {
@@ -13,43 +13,58 @@ import {
   FontName,
   FontRow,
   FontRowMain,
+  Hint,
   HiddenInput,
   Mascot,
   Overlay,
-  PickButton,
-  PickHint,
-  Picker,
-  RecheckButton,
   Resolved,
+  RowRight,
   SecondaryButton,
   StatusChip,
   SubstituteNote,
   TextGroup,
   Title,
+  UploadButton,
 } from "./FontRequirementPrompt.styles";
 
 interface Props {
   fontReport: FontReportEntry[];
-  busy: boolean;
+  busy: boolean; // 변환(finalize) 진행 중
+  uploadingName: string | null; // 현재 업로드 중인 폰트명
   error: string | null;
-  onCheckFonts: (files: File[]) => void;
-  onUploadFonts: (files: File[]) => void;
+  onUploadFont: (fontName: string, file: File) => void;
+  onContinue: () => void;
   onProceedWithout: () => void;
 }
 
 export default function FontRequirementPrompt({
   fontReport,
   busy,
+  uploadingName,
   error,
-  onCheckFonts,
-  onUploadFonts,
+  onUploadFont,
+  onContinue,
   onProceedWithout,
 }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const [picked, setPicked] = useState<File[]>([]);
+  const targetRef = useRef<string | null>(null);
+
   const missingCount = fontReport.filter((f) => f.status === "MISSING").length;
   const allResolved = missingCount === 0;
-  const hasPicked = picked.length > 0;
+  const anyBusy = busy || uploadingName !== null;
+
+  const openPicker = (fontName: string) => {
+    targetRef.current = fontName;
+    inputRef.current?.click();
+  };
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    const name = targetRef.current;
+    e.target.value = ""; // 같은 파일도 다시 선택할 수 있게 초기화
+    targetRef.current = null;
+    if (file && name) onUploadFont(name, file);
+  };
 
   return (
     <Overlay>
@@ -58,13 +73,13 @@ export default function FontRequirementPrompt({
           <Body>
             <Mascot src={FontMascot} alt="" aria-hidden="true" />
             <TextGroup>
-              <Title id="font-modal-title">발표에 사용된 폰트를 확인해 주세요</Title>
+              <Title id="font-modal-title">발표 자료에 사용된 폰트를 확인해 주세요</Title>
               {allResolved ? (
-                <Resolved>필요한 폰트가 모두 준비되었어요. 이대로 계속 진행하세요.</Resolved>
+                <Resolved>필요한 폰트가 모두 준비되었어요.</Resolved>
               ) : (
                 <Description>
-                  정확한 글꼴로 변환하려면 아래 <b>{missingCount}</b>개의 폰트를 업로드하세요. 업로드하지
-                  않으면 서버의 기본 글꼴로 대체돼요.
+                  정확한 폰트로 변환하려면 각 폰트 오른쪽의 <b>업로드</b>를 눌러 파일을 올려주세요. 올리지
+                  않은 폰트는 대체 글꼴로 대체돼요.
                 </Description>
               )}
             </TextGroup>
@@ -73,46 +88,40 @@ export default function FontRequirementPrompt({
           <FontList aria-label="필요한 폰트 목록">
             {fontReport.map((f) => {
               const missing = f.status === "MISSING";
+              const isUploading = uploadingName === f.name;
               return (
                 <FontRow key={f.name}>
                   <FontRowMain>
                     <FontName>{f.name}</FontName>
-                    <StatusChip $missing={missing} aria-label={missing ? "없음" : "사용 가능"}>
-                      {missing ? "없음" : "사용 가능"}
-                    </StatusChip>
+                    <RowRight>
+                      <StatusChip $missing={missing} aria-label={missing ? "없음" : "사용 가능"}>
+                        {missing ? "없음" : "사용 가능"}
+                      </StatusChip>
+                      {missing && (
+                        <UploadButton type="button" disabled={anyBusy} onClick={() => openPicker(f.name)}>
+                          {isUploading ? "업로드 중…" : "업로드"}
+                        </UploadButton>
+                      )}
+                    </RowRight>
                   </FontRowMain>
                   {missing && f.substitute && <SubstituteNote>대체 글꼴: {f.substitute}</SubstituteNote>}
                 </FontRow>
               );
             })}
           </FontList>
+          <Hint>.ttf · .otf · .ttc · 최대 15MB</Hint>
 
-          <Picker>
-            <HiddenInput
-              ref={inputRef}
-              type="file"
-              accept=".ttf,.otf,.ttc"
-              multiple
-              onChange={(e) => setPicked(Array.from(e.target.files ?? []))}
-            />
-            <PickButton type="button" onClick={() => inputRef.current?.click()}>
-              {hasPicked ? `${picked.length}개 폰트 선택됨` : "폰트 파일 선택"}
-            </PickButton>
-            <PickHint>.ttf · .otf · .ttc · 최대 15MB</PickHint>
-            <RecheckButton type="button" disabled={busy || !hasPicked} onClick={() => onCheckFonts(picked)}>
-              선택한 폰트로 다시 확인
-            </RecheckButton>
-          </Picker>
+          <HiddenInput ref={inputRef} type="file" accept=".ttf,.otf,.ttc" onChange={handleFileChange} />
 
           {error && <ErrorText role="alert">{error}</ErrorText>}
         </Content>
 
         <Footer>
-          <SecondaryButton type="button" disabled={busy} onClick={onProceedWithout}>
+          <SecondaryButton type="button" disabled={anyBusy} onClick={onProceedWithout}>
             그냥 진행
           </SecondaryButton>
-          <ConfirmButton type="button" disabled={busy || !hasPicked} onClick={() => onUploadFonts(picked)}>
-            이 폰트로 계속
+          <ConfirmButton type="button" disabled={anyBusy} onClick={onContinue}>
+            변환 시작
           </ConfirmButton>
         </Footer>
       </Dialog>

--- a/src/pages/session-create/ui/FontRequirementPrompt.tsx
+++ b/src/pages/session-create/ui/FontRequirementPrompt.tsx
@@ -12,6 +12,7 @@ import {
   FontList,
   FontName,
   FontRow,
+  FontRowMain,
   HiddenInput,
   Mascot,
   Overlay,
@@ -22,6 +23,7 @@ import {
   Resolved,
   SecondaryButton,
   StatusChip,
+  SubstituteNote,
   TextGroup,
   Title,
 } from "./FontRequirementPrompt.styles";
@@ -73,10 +75,13 @@ export default function FontRequirementPrompt({
               const missing = f.status === "MISSING";
               return (
                 <FontRow key={f.name}>
-                  <FontName>{f.name}</FontName>
-                  <StatusChip $missing={missing} aria-label={missing ? "없음" : "사용 가능"}>
-                    {missing ? "없음" : "사용 가능"}
-                  </StatusChip>
+                  <FontRowMain>
+                    <FontName>{f.name}</FontName>
+                    <StatusChip $missing={missing} aria-label={missing ? "없음" : "사용 가능"}>
+                      {missing ? "없음" : "사용 가능"}
+                    </StatusChip>
+                  </FontRowMain>
+                  {missing && f.substitute && <SubstituteNote>대체 글꼴: {f.substitute}</SubstituteNote>}
                 </FontRow>
               );
             })}
@@ -93,7 +98,7 @@ export default function FontRequirementPrompt({
             <PickButton type="button" onClick={() => inputRef.current?.click()}>
               {hasPicked ? `${picked.length}개 폰트 선택됨` : "폰트 파일 선택"}
             </PickButton>
-            <PickHint>.ttf · .otf · .ttc · 최대 20MB</PickHint>
+            <PickHint>.ttf · .otf · .ttc · 최대 15MB</PickHint>
             <RecheckButton type="button" disabled={busy || !hasPicked} onClick={() => onCheckFonts(picked)}>
               선택한 폰트로 다시 확인
             </RecheckButton>

--- a/src/pages/session-create/ui/FontRequirementPrompt.tsx
+++ b/src/pages/session-create/ui/FontRequirementPrompt.tsx
@@ -1,9 +1,10 @@
-import { useRef, type ChangeEvent } from "react";
+import { useCallback, useEffect, useRef, useState, type ChangeEvent } from "react";
 import type { FontReportEntry } from "@/shared/api/model/pdf";
 import FontMascot from "@/shared/assets/images/session-warning-face.svg";
 import {
   Body,
   ConfirmButton,
+  ConfirmOverlay,
   Content,
   Description,
   Dialog,
@@ -15,10 +16,12 @@ import {
   FontRowMain,
   Hint,
   HiddenInput,
+  ListWrap,
   Mascot,
   Overlay,
   Resolved,
   RowRight,
+  ScrollFade,
   SecondaryButton,
   StatusChip,
   SubstituteNote,
@@ -51,10 +54,26 @@ export default function FontRequirementPrompt({
 }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const targetRef = useRef<string | null>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const [showFade, setShowFade] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   const missingCount = fontReport.filter((f) => f.status === "MISSING").length;
   const allResolved = missingCount === 0;
   const anyBusy = busy || uploadingName !== null;
+
+  // 목록이 넘칠 때만, 그리고 아직 맨 아래가 아닐 때만 하단 그라데이션(스크롤 유도)을 보인다.
+  const syncFade = useCallback(() => {
+    const el = listRef.current;
+    if (!el) return;
+    const overflowing = el.scrollHeight > el.clientHeight + 1;
+    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 1;
+    setShowFade(overflowing && !atBottom);
+  }, []);
+
+  useEffect(() => {
+    syncFade();
+  }, [fontReport, syncFade]);
 
   const openPicker = (fontName: string) => {
     targetRef.current = fontName;
@@ -69,72 +88,114 @@ export default function FontRequirementPrompt({
     if (file && name) onUploadFont(name, file);
   };
 
+  const handleContinueClick = () => {
+    if (missingCount > 0) setConfirmOpen(true);
+    else onContinue();
+  };
+
   return (
-    <Overlay>
-      <Dialog role="dialog" aria-modal="true" aria-labelledby="font-modal-title">
-        <Content>
-          <Body>
-            <Mascot src={FontMascot} alt="" aria-hidden="true" />
-            <TextGroup>
-              <Title id="font-modal-title">발표 자료에 사용된 폰트를 확인해 주세요</Title>
-              {allResolved ? (
-                <Resolved>필요한 폰트가 모두 준비되었어요.</Resolved>
-              ) : (
-                <Description>
-                  정확한 폰트로 변환하려면 각 폰트 오른쪽의 <b>업로드</b>를 눌러 파일을 올려주세요. 올리지
-                  않은 폰트는 대체 글꼴로 대체돼요.
-                </Description>
-              )}
-            </TextGroup>
-          </Body>
+    <>
+      <Overlay>
+        <Dialog role="dialog" aria-modal="true" aria-labelledby="font-modal-title">
+          <Content>
+            <Body>
+              <Mascot src={FontMascot} alt="" aria-hidden="true" />
+              <TextGroup>
+                <Title id="font-modal-title">발표 자료에 사용된 폰트를 확인해 주세요</Title>
+                {allResolved ? (
+                  <Resolved>필요한 폰트가 모두 준비되었어요.</Resolved>
+                ) : (
+                  <Description>
+                    정확한 폰트로 변환하려면 각 폰트 오른쪽의 <b>업로드</b>를 눌러 파일을 올려주세요. 올리지
+                    않은 폰트는 대체 글꼴로 대체돼요.
+                  </Description>
+                )}
+              </TextGroup>
+            </Body>
 
-          <FontList aria-label="필요한 폰트 목록">
-            {fontReport.map((f) => {
-              const missing = f.status === "MISSING";
-              const isUploading = uploadingName === f.name;
-              return (
-                <FontRow key={f.name}>
-                  <FontRowMain>
-                    <FontName>{f.name}</FontName>
-                    <RowRight>
-                      <StatusChip $missing={missing} aria-label={missing ? "없음" : "사용 가능"}>
-                        {missing ? "없음" : "사용 가능"}
-                      </StatusChip>
-                      {missing && (
-                        <UploadButton type="button" disabled={anyBusy} onClick={() => openPicker(f.name)}>
-                          {isUploading ? "업로드 중…" : "업로드"}
-                        </UploadButton>
+            <ListWrap>
+              <FontList ref={listRef} onScroll={syncFade} aria-label="필요한 폰트 목록">
+                {fontReport.map((f) => {
+                  const missing = f.status === "MISSING";
+                  const isUploading = uploadingName === f.name;
+                  return (
+                    <FontRow key={f.name}>
+                      <FontRowMain>
+                        <FontName>{f.name}</FontName>
+                        <RowRight>
+                          <StatusChip $missing={missing} aria-label={missing ? "없음" : "사용 가능"}>
+                            {missing ? "없음" : "사용 가능"}
+                          </StatusChip>
+                          {missing && (
+                            <UploadButton type="button" disabled={anyBusy} onClick={() => openPicker(f.name)}>
+                              {isUploading ? "업로드 중…" : "업로드"}
+                            </UploadButton>
+                          )}
+                        </RowRight>
+                      </FontRowMain>
+                      {missing && warnings[f.name] !== undefined ? (
+                        <WarningNote>
+                          업로드한 파일이 이 폰트와 달라요
+                          {warnings[f.name] ? ` (올린 폰트: ${warnings[f.name]})` : ""}.
+                        </WarningNote>
+                      ) : (
+                        missing && f.substitute && <SubstituteNote>대체 글꼴: {f.substitute}</SubstituteNote>
                       )}
-                    </RowRight>
-                  </FontRowMain>
-                  {missing && warnings[f.name] !== undefined ? (
-                    <WarningNote>
-                      업로드한 파일이 이 폰트와 달라요
-                      {warnings[f.name] ? ` (올린 폰트: ${warnings[f.name]})` : ""}.
-                    </WarningNote>
-                  ) : (
-                    missing && f.substitute && <SubstituteNote>대체 글꼴: {f.substitute}</SubstituteNote>
-                  )}
-                </FontRow>
-              );
-            })}
-          </FontList>
-          <Hint>.ttf · .otf · .ttc · 최대 15MB</Hint>
+                    </FontRow>
+                  );
+                })}
+              </FontList>
+              {showFade && <ScrollFade aria-hidden="true" />}
+            </ListWrap>
+            <Hint>.ttf · .otf · .ttc · 최대 15MB</Hint>
 
-          <HiddenInput ref={inputRef} type="file" accept=".ttf,.otf,.ttc" onChange={handleFileChange} />
+            <HiddenInput ref={inputRef} type="file" accept=".ttf,.otf,.ttc" onChange={handleFileChange} />
 
-          {error && <ErrorText role="alert">{error}</ErrorText>}
-        </Content>
+            {error && <ErrorText role="alert">{error}</ErrorText>}
+          </Content>
 
-        <Footer>
-          <SecondaryButton type="button" disabled={anyBusy} onClick={onProceedWithout}>
-            그냥 진행
-          </SecondaryButton>
-          <ConfirmButton type="button" disabled={anyBusy} onClick={onContinue}>
-            변환 시작
-          </ConfirmButton>
-        </Footer>
-      </Dialog>
-    </Overlay>
+          <Footer>
+            <SecondaryButton type="button" disabled={anyBusy} onClick={onProceedWithout}>
+              그냥 진행
+            </SecondaryButton>
+            <ConfirmButton type="button" disabled={anyBusy} onClick={handleContinueClick}>
+              변환 시작
+            </ConfirmButton>
+          </Footer>
+        </Dialog>
+      </Overlay>
+
+      {confirmOpen && (
+        <ConfirmOverlay>
+          <Dialog role="alertdialog" aria-modal="true" aria-labelledby="font-confirm-title">
+            <Content>
+              <Body>
+                <TextGroup>
+                  <Title id="font-confirm-title">아직 준비되지 않은 폰트가 있어요</Title>
+                  <Description>
+                    남은 <b>{missingCount}</b>개의 폰트는 서버의 대체 글꼴로 대체돼요. 그래도 변환을
+                    시작할까요?
+                  </Description>
+                </TextGroup>
+              </Body>
+            </Content>
+            <Footer>
+              <SecondaryButton type="button" onClick={() => setConfirmOpen(false)}>
+                취소
+              </SecondaryButton>
+              <ConfirmButton
+                type="button"
+                onClick={() => {
+                  setConfirmOpen(false);
+                  onContinue();
+                }}
+              >
+                네, 시작할게요
+              </ConfirmButton>
+            </Footer>
+          </Dialog>
+        </ConfirmOverlay>
+      )}
+    </>
   );
 }

--- a/src/pages/session-create/ui/FontRequirementPrompt.tsx
+++ b/src/pages/session-create/ui/FontRequirementPrompt.tsx
@@ -1,5 +1,30 @@
 import { useRef, useState } from "react";
 import type { FontReportEntry } from "@/shared/api/model/pdf";
+import FontMascot from "@/shared/assets/images/session-warning-face.svg";
+import {
+  Body,
+  ConfirmButton,
+  Content,
+  Description,
+  Dialog,
+  ErrorText,
+  Footer,
+  FontList,
+  FontName,
+  FontRow,
+  HiddenInput,
+  Mascot,
+  Overlay,
+  PickButton,
+  PickHint,
+  Picker,
+  RecheckButton,
+  Resolved,
+  SecondaryButton,
+  StatusChip,
+  TextGroup,
+  Title,
+} from "./FontRequirementPrompt.styles";
 
 interface Props {
   fontReport: FontReportEntry[];
@@ -22,53 +47,70 @@ export default function FontRequirementPrompt({
   const [picked, setPicked] = useState<File[]>([]);
   const missingCount = fontReport.filter((f) => f.status === "MISSING").length;
   const allResolved = missingCount === 0;
+  const hasPicked = picked.length > 0;
 
   return (
-    <div role="dialog" aria-label="폰트 업로드" style={{ maxWidth: 560, margin: "10vh auto", padding: 24 }}>
-      <h2>이 발표 자료에 필요한 폰트가 서버에 없어요</h2>
-      {allResolved ? (
-        <p style={{ color: "#1a7f37" }}>✅ 모든 폰트가 준비되었어요. 계속 진행하세요.</p>
-      ) : (
-        <p>
-          정확한 글꼴로 변환하려면 아래 <b>{missingCount}</b>개의 폰트를 업로드하세요.
-        </p>
-      )}
-      <ul>
-        {fontReport.map((f) => (
-          <li key={f.name}>
-            <span>{f.name}</span>{" "}
-            <span aria-label={f.status}>{f.status === "MISSING" ? "❌ 없음" : "✅ 사용 가능"}</span>
-          </li>
-        ))}
-      </ul>
-      <input
-        ref={inputRef}
-        type="file"
-        accept=".ttf,.otf,.ttc"
-        multiple
-        onChange={(e) => setPicked(Array.from(e.target.files ?? []))}
-      />
-      {picked.length > 0 && <p>{picked.length}개 선택됨</p>}
-      <button
-        type="button"
-        disabled={busy || picked.length === 0}
-        onClick={() => onCheckFonts(picked)}
-      >
-        선택한 폰트로 다시 확인
-      </button>
-      {error && (
-        <p role="alert" style={{ color: "#e8541e" }}>
-          {error}
-        </p>
-      )}
-      <div style={{ display: "flex", gap: 8, marginTop: 16 }}>
-        <button type="button" disabled={busy || picked.length === 0} onClick={() => onUploadFonts(picked)}>
-          이 폰트로 계속
-        </button>
-        <button type="button" disabled={busy} onClick={onProceedWithout}>
-          그냥 진행
-        </button>
-      </div>
-    </div>
+    <Overlay>
+      <Dialog role="dialog" aria-modal="true" aria-labelledby="font-modal-title">
+        <Content>
+          <Body>
+            <Mascot src={FontMascot} alt="" aria-hidden="true" />
+            <TextGroup>
+              <Title id="font-modal-title">발표에 사용된 폰트를 확인해 주세요</Title>
+              {allResolved ? (
+                <Resolved>필요한 폰트가 모두 준비되었어요. 이대로 계속 진행하세요.</Resolved>
+              ) : (
+                <Description>
+                  정확한 글꼴로 변환하려면 아래 <b>{missingCount}</b>개의 폰트를 업로드하세요. 업로드하지
+                  않으면 서버의 기본 글꼴로 대체돼요.
+                </Description>
+              )}
+            </TextGroup>
+          </Body>
+
+          <FontList aria-label="필요한 폰트 목록">
+            {fontReport.map((f) => {
+              const missing = f.status === "MISSING";
+              return (
+                <FontRow key={f.name}>
+                  <FontName>{f.name}</FontName>
+                  <StatusChip $missing={missing} aria-label={missing ? "없음" : "사용 가능"}>
+                    {missing ? "없음" : "사용 가능"}
+                  </StatusChip>
+                </FontRow>
+              );
+            })}
+          </FontList>
+
+          <Picker>
+            <HiddenInput
+              ref={inputRef}
+              type="file"
+              accept=".ttf,.otf,.ttc"
+              multiple
+              onChange={(e) => setPicked(Array.from(e.target.files ?? []))}
+            />
+            <PickButton type="button" onClick={() => inputRef.current?.click()}>
+              {hasPicked ? `${picked.length}개 폰트 선택됨` : "폰트 파일 선택"}
+            </PickButton>
+            <PickHint>.ttf · .otf · .ttc · 최대 20MB</PickHint>
+            <RecheckButton type="button" disabled={busy || !hasPicked} onClick={() => onCheckFonts(picked)}>
+              선택한 폰트로 다시 확인
+            </RecheckButton>
+          </Picker>
+
+          {error && <ErrorText role="alert">{error}</ErrorText>}
+        </Content>
+
+        <Footer>
+          <SecondaryButton type="button" disabled={busy} onClick={onProceedWithout}>
+            그냥 진행
+          </SecondaryButton>
+          <ConfirmButton type="button" disabled={busy || !hasPicked} onClick={() => onUploadFonts(picked)}>
+            이 폰트로 계속
+          </ConfirmButton>
+        </Footer>
+      </Dialog>
+    </Overlay>
   );
 }

--- a/src/pages/session-create/ui/SessionCreatePage.tsx
+++ b/src/pages/session-create/ui/SessionCreatePage.tsx
@@ -25,6 +25,9 @@ import { createRoom } from "@/shared/api/room";
 import { fetchSlidesMeta, fetchAllOriginalSlideUrls } from "@/shared/api/presentation";
 import websocketService from "@/shared/api/websocket";
 import { useBroadcastPublisher, useBroadcastReactionVisibility } from "@/shared/lib/broadcast";
+import { uploadFonts, finalizeUpload } from "@/shared/api/pdfFonts";
+import FontRequirementPrompt from "./FontRequirementPrompt";
+import type { ChunkUploadReady, FontReportEntry } from "@/shared/api/model/pdf";
 
 const log = createLogger("session-create");
 
@@ -40,6 +43,10 @@ const PresentationPrepPage = () => {
   const [roomData, setRoomData] = useState<any>(initialRoomData);
   const [restoredSlides, setRestoredSlides] = useState<(string | null)[] | null>(null);
   const [fatalMessage, setFatalMessage] = useState<string | null>(null);
+  const [pendingFonts, setPendingFonts] = useState<{ uploadId: string; fontReport: FontReportEntry[] } | null>(null);
+  const [fontBusy, setFontBusy] = useState(false);
+  const [fontError, setFontError] = useState<string | null>(null);
+  const pendingRoomRef = useRef<any>(null);
 
   const roomId = useMemo(() => roomIdParam || roomData?.roomId || null, [roomIdParam, roomData]);
   const quickSettingsStorageKey = roomId ? storageKeys.quickSettings(String(roomId)) : null;
@@ -311,6 +318,71 @@ const PresentationPrepPage = () => {
     restoredSlides,
   ]);
 
+  const applyReady = useCallback(
+    (room: any, ready: ChunkUploadReady) => {
+      const nextRoomData = {
+        ...room,
+        deckId: room.deckId,
+        totalPages: ready.totalPages,
+        pdfId: ready.pdfId,
+        fileName: ready.fileName,
+        canStartSession: false,
+        pdfDownloadEnabled: false,
+      };
+      setRoomData(nextRoomData);
+      setTotalPages(ready.totalPages);
+      setStreamUrl(ready.streamUrl);
+      sessionStorage.setItem("boini_room", JSON.stringify(nextRoomData));
+      setPendingFonts(null);
+
+      if (roomIdParam !== room.roomId) {
+        navigate(`/rooms/${room.roomId}`, {
+          replace: true,
+          state: {
+            ...(location.state || {}),
+            roomData: nextRoomData,
+            roomId: room.roomId,
+            deckId: room.deckId,
+            totalPages: ready.totalPages,
+          },
+        });
+      }
+    },
+    [navigate, roomIdParam, location.state]
+  );
+
+  const handleUploadFonts = useCallback(
+    async (files: File[]) => {
+      if (!pendingFonts) return;
+      setFontBusy(true);
+      setFontError(null);
+      try {
+        await uploadFonts(pendingFonts.uploadId, files);
+        const ready = await finalizeUpload(pendingFonts.uploadId, false);
+        applyReady(pendingRoomRef.current, ready);
+      } catch {
+        setFontError("폰트 업로드에 실패했습니다. 다시 시도해주세요.");
+      } finally {
+        setFontBusy(false);
+      }
+    },
+    [pendingFonts, applyReady]
+  );
+
+  const handleProceedWithout = useCallback(async () => {
+    if (!pendingFonts) return;
+    setFontBusy(true);
+    setFontError(null);
+    try {
+      const ready = await finalizeUpload(pendingFonts.uploadId, true);
+      applyReady(pendingRoomRef.current, ready);
+    } catch {
+      setFontError("변환을 시작하지 못했습니다. 다시 시도해주세요.");
+    } finally {
+      setFontBusy(false);
+    }
+  }, [pendingFonts, applyReady]);
+
   // 신규 업로드 플로우: createRoom → 청크 업로드 → SSE 스트림 구독
   useEffect(() => {
     if (hasInitializedRef.current) return;
@@ -343,41 +415,13 @@ const PresentationPrepPage = () => {
         // BE 는 totalPages >= 1 을 요구하므로 placeholder 로 1 을 보낸다.
         // 실제 총 페이지는 업로드 조립 완료 응답(ready.totalPages) 에서 확정된다.
         const room = await createRoom(1);
+        pendingRoomRef.current = room;
         const terminal = await uploadPdf(sourceFile, room.roomId, room.deckId);
-        // NEEDS_FONTS 분기(폰트 업로드 프롬프트)는 별도 작업에서 연결 예정이므로,
-        // 현재는 READY 가 아니면 업로드 실패로 처리한다.
-        if (terminal.status !== "READY") {
-          throw new Error("이 발표 자료에 필요한 폰트가 서버에 없습니다.");
+        if (terminal.status === "NEEDS_FONTS") {
+          setPendingFonts({ uploadId: terminal.uploadId, fontReport: terminal.fontReport });
+          return; // Phase B는 사용자 액션(폰트 업로드/그냥 진행)으로 트리거됨
         }
-        const ready = terminal;
-
-        const nextRoomData = {
-          ...room,
-          deckId: room.deckId,
-          totalPages: ready.totalPages,
-          pdfId: ready.pdfId,
-          fileName: ready.fileName,
-          canStartSession: false,
-          pdfDownloadEnabled: false,
-        };
-
-        setRoomData(nextRoomData);
-        setTotalPages(ready.totalPages);
-        setStreamUrl(ready.streamUrl);
-        sessionStorage.setItem("boini_room", JSON.stringify(nextRoomData));
-
-        if (roomIdParam !== room.roomId) {
-          navigate(`/rooms/${room.roomId}`, {
-            replace: true,
-            state: {
-              ...(location.state || {}),
-              roomData: nextRoomData,
-              roomId: room.roomId,
-              deckId: room.deckId,
-              totalPages: ready.totalPages,
-            },
-          });
-        }
+        applyReady(room, terminal);
       } catch (err) {
         log.error("발표 자료 업로드/스트림 준비 실패:", err);
         hasInitializedRef.current = false;
@@ -394,6 +438,7 @@ const PresentationPrepPage = () => {
     location.state,
     uploadPdf,
     setCanStartSessionAtomValue,
+    applyReady,
   ]);
 
   // canStartSession 이 true 가 되면 atom + roomData + sessionStorage 를 모두 동기화.
@@ -496,6 +541,18 @@ const PresentationPrepPage = () => {
 
   if (fatalMessage) {
     return <SessionLoadingOverlay message={`⚠️ ${fatalMessage}`} />;
+  }
+
+  if (pendingFonts) {
+    return (
+      <FontRequirementPrompt
+        fontReport={pendingFonts.fontReport}
+        busy={fontBusy}
+        error={fontError}
+        onUploadFonts={handleUploadFonts}
+        onProceedWithout={handleProceedWithout}
+      />
+    );
   }
 
   // 오버레이는 "아직 대시보드를 그릴 근거가 없는 동안"에만 띄운다.

--- a/src/pages/session-create/ui/SessionCreatePage.tsx
+++ b/src/pages/session-create/ui/SessionCreatePage.tsx
@@ -46,6 +46,7 @@ const PresentationPrepPage = () => {
   const [pendingFonts, setPendingFonts] = useState<{ uploadId: string; fontReport: FontReportEntry[] } | null>(null);
   const [fontBusy, setFontBusy] = useState(false);
   const [uploadingName, setUploadingName] = useState<string | null>(null);
+  const [fontWarnings, setFontWarnings] = useState<Record<string, string>>({});
   const [fontError, setFontError] = useState<string | null>(null);
   const pendingRoomRef = useRef<any>(null);
 
@@ -359,8 +360,15 @@ const PresentationPrepPage = () => {
       setUploadingName(fontName);
       setFontError(null);
       try {
-        const report = await uploadFonts(pendingFonts.uploadId, [file]);
-        setPendingFonts((prev) => (prev ? { ...prev, fontReport: report } : prev));
+        const res = await uploadFonts(pendingFonts.uploadId, [file], fontName);
+        setPendingFonts((prev) => (prev ? { ...prev, fontReport: res.report } : prev));
+        setFontWarnings((prev) => {
+          const next = { ...prev };
+          // 방금 올린 파일이 이 요구 폰트와 이름이 다르면 경고를 남기고, 일치하면 지운다.
+          if (res.matched === false) next[fontName] = res.uploadedFamilies?.[0] ?? "";
+          else delete next[fontName];
+          return next;
+        });
       } catch {
         setFontError("폰트 업로드에 실패했습니다. 다시 시도해주세요.");
       } finally {
@@ -567,6 +575,7 @@ const PresentationPrepPage = () => {
           fontReport={pendingFonts.fontReport}
           busy={fontBusy}
           uploadingName={uploadingName}
+          warnings={fontWarnings}
           error={fontError}
           onUploadFont={handleUploadFont}
           onContinue={handleContinue}

--- a/src/pages/session-create/ui/SessionCreatePage.tsx
+++ b/src/pages/session-create/ui/SessionCreatePage.tsx
@@ -45,6 +45,7 @@ const PresentationPrepPage = () => {
   const [fatalMessage, setFatalMessage] = useState<string | null>(null);
   const [pendingFonts, setPendingFonts] = useState<{ uploadId: string; fontReport: FontReportEntry[] } | null>(null);
   const [fontBusy, setFontBusy] = useState(false);
+  const [uploadingName, setUploadingName] = useState<string | null>(null);
   const [fontError, setFontError] = useState<string | null>(null);
   const pendingRoomRef = useRef<any>(null);
 
@@ -351,22 +352,22 @@ const PresentationPrepPage = () => {
     [navigate, roomIdParam, location.state]
   );
 
-  const handleUploadFonts = useCallback(
-    async (files: File[]) => {
+  // 개별 폰트를 업로드해 서버에 등록하고, 갱신된 리포트로 배지를 바꾼다(변환은 하지 않음).
+  const handleUploadFont = useCallback(
+    async (fontName: string, file: File) => {
       if (!pendingFonts) return;
-      setFontBusy(true);
+      setUploadingName(fontName);
       setFontError(null);
       try {
-        await uploadFonts(pendingFonts.uploadId, files);
-        const ready = await finalizeUpload(pendingFonts.uploadId, false);
-        applyReady(pendingRoomRef.current, ready);
+        const report = await uploadFonts(pendingFonts.uploadId, [file]);
+        setPendingFonts((prev) => (prev ? { ...prev, fontReport: report } : prev));
       } catch {
         setFontError("폰트 업로드에 실패했습니다. 다시 시도해주세요.");
       } finally {
-        setFontBusy(false);
+        setUploadingName(null);
       }
     },
-    [pendingFonts, applyReady]
+    [pendingFonts]
   );
 
   const handleProceedWithout = useCallback(async () => {
@@ -383,23 +384,20 @@ const PresentationPrepPage = () => {
     }
   }, [pendingFonts, applyReady]);
 
-  // 선택한 폰트를 업로드해 서버에 등록하고, 새 리포트로 배지를 갱신한다(변환은 하지 않음).
-  const handleCheckFonts = useCallback(
-    async (files: File[]) => {
-      if (!pendingFonts) return;
-      setFontBusy(true);
-      setFontError(null);
-      try {
-        const report = await uploadFonts(pendingFonts.uploadId, files);
-        setPendingFonts((prev) => (prev ? { ...prev, fontReport: report } : prev));
-      } catch {
-        setFontError("폰트 확인에 실패했습니다. 다시 시도해주세요.");
-      } finally {
-        setFontBusy(false);
-      }
-    },
-    [pendingFonts]
-  );
+  // 업로드한 폰트로 변환을 시작한다(finalize).
+  const handleContinue = useCallback(async () => {
+    if (!pendingFonts) return;
+    setFontBusy(true);
+    setFontError(null);
+    try {
+      const ready = await finalizeUpload(pendingFonts.uploadId, false);
+      applyReady(pendingRoomRef.current, ready);
+    } catch {
+      setFontError("변환을 시작하지 못했습니다. 다시 시도해주세요.");
+    } finally {
+      setFontBusy(false);
+    }
+  }, [pendingFonts, applyReady]);
 
   // 신규 업로드 플로우: createRoom → 청크 업로드 → SSE 스트림 구독
   useEffect(() => {
@@ -568,9 +566,10 @@ const PresentationPrepPage = () => {
         <FontRequirementPrompt
           fontReport={pendingFonts.fontReport}
           busy={fontBusy}
+          uploadingName={uploadingName}
           error={fontError}
-          onCheckFonts={handleCheckFonts}
-          onUploadFonts={handleUploadFonts}
+          onUploadFont={handleUploadFont}
+          onContinue={handleContinue}
           onProceedWithout={handleProceedWithout}
         />
       </>

--- a/src/pages/session-create/ui/SessionCreatePage.tsx
+++ b/src/pages/session-create/ui/SessionCreatePage.tsx
@@ -563,14 +563,17 @@ const PresentationPrepPage = () => {
 
   if (pendingFonts) {
     return (
-      <FontRequirementPrompt
-        fontReport={pendingFonts.fontReport}
-        busy={fontBusy}
-        error={fontError}
-        onCheckFonts={handleCheckFonts}
-        onUploadFonts={handleUploadFonts}
-        onProceedWithout={handleProceedWithout}
-      />
+      <>
+        <SessionLoadingOverlay message="발표 자료 준비 중..." />
+        <FontRequirementPrompt
+          fontReport={pendingFonts.fontReport}
+          busy={fontBusy}
+          error={fontError}
+          onCheckFonts={handleCheckFonts}
+          onUploadFonts={handleUploadFonts}
+          onProceedWithout={handleProceedWithout}
+        />
+      </>
     );
   }
 

--- a/src/pages/session-create/ui/SessionCreatePage.tsx
+++ b/src/pages/session-create/ui/SessionCreatePage.tsx
@@ -361,14 +361,26 @@ const PresentationPrepPage = () => {
       setFontError(null);
       try {
         const res = await uploadFonts(pendingFonts.uploadId, [file], fontName);
-        setPendingFonts((prev) => (prev ? { ...prev, fontReport: res.report } : prev));
-        setFontWarnings((prev) => {
-          const next = { ...prev };
-          // 방금 올린 파일이 이 요구 폰트와 이름이 다르면 경고를 남기고, 일치하면 지운다.
-          if (res.matched === false) next[fontName] = res.uploadedFamilies?.[0] ?? "";
-          else delete next[fontName];
-          return next;
-        });
+        // 서버는 전체 리포트를 재분석하지 않으므로, 일치하면 해당 폰트만 로컬에서 '사용 가능'으로 바꾼다.
+        if (res.matched) {
+          setPendingFonts((prev) =>
+            prev
+              ? {
+                  ...prev,
+                  fontReport: prev.fontReport.map((e) =>
+                    e.name === fontName ? { ...e, status: "AVAILABLE" as const, installed: true } : e
+                  ),
+                }
+              : prev
+          );
+          setFontWarnings((prev) => {
+            const next = { ...prev };
+            delete next[fontName];
+            return next;
+          });
+        } else {
+          setFontWarnings((prev) => ({ ...prev, [fontName]: res.uploadedFamilies?.[0] ?? "" }));
+        }
       } catch {
         setFontError("폰트 업로드에 실패했습니다. 다시 시도해주세요.");
       } finally {

--- a/src/pages/session-create/ui/SessionCreatePage.tsx
+++ b/src/pages/session-create/ui/SessionCreatePage.tsx
@@ -383,6 +383,24 @@ const PresentationPrepPage = () => {
     }
   }, [pendingFonts, applyReady]);
 
+  // 선택한 폰트를 업로드해 서버에 등록하고, 새 리포트로 배지를 갱신한다(변환은 하지 않음).
+  const handleCheckFonts = useCallback(
+    async (files: File[]) => {
+      if (!pendingFonts) return;
+      setFontBusy(true);
+      setFontError(null);
+      try {
+        const report = await uploadFonts(pendingFonts.uploadId, files);
+        setPendingFonts((prev) => (prev ? { ...prev, fontReport: report } : prev));
+      } catch {
+        setFontError("폰트 확인에 실패했습니다. 다시 시도해주세요.");
+      } finally {
+        setFontBusy(false);
+      }
+    },
+    [pendingFonts]
+  );
+
   // 신규 업로드 플로우: createRoom → 청크 업로드 → SSE 스트림 구독
   useEffect(() => {
     if (hasInitializedRef.current) return;
@@ -549,6 +567,7 @@ const PresentationPrepPage = () => {
         fontReport={pendingFonts.fontReport}
         busy={fontBusy}
         error={fontError}
+        onCheckFonts={handleCheckFonts}
         onUploadFonts={handleUploadFonts}
         onProceedWithout={handleProceedWithout}
       />

--- a/src/pages/session-create/ui/SessionCreatePage.tsx
+++ b/src/pages/session-create/ui/SessionCreatePage.tsx
@@ -566,16 +566,19 @@ const PresentationPrepPage = () => {
     return (
       <>
         <SessionLoadingOverlay message="발표 자료 준비 중..." />
-        <FontRequirementPrompt
-          fontReport={pendingFonts.fontReport}
-          busy={fontBusy}
-          uploadingName={uploadingName}
-          warnings={fontWarnings}
-          error={fontError}
-          onUploadFont={handleUploadFont}
-          onContinue={handleContinue}
-          onProceedWithout={handleProceedWithout}
-        />
+        {/* 변환(finalize) 시작하면 모달을 닫아, 사용자가 '준비 중' 로딩 화면을 보게 한다. */}
+        {!fontBusy && (
+          <FontRequirementPrompt
+            fontReport={pendingFonts.fontReport}
+            busy={fontBusy}
+            uploadingName={uploadingName}
+            warnings={fontWarnings}
+            error={fontError}
+            onUploadFont={handleUploadFont}
+            onContinue={handleContinue}
+            onProceedWithout={handleProceedWithout}
+          />
+        )}
       </>
     );
   }

--- a/src/pages/session-create/ui/SessionCreatePage.tsx
+++ b/src/pages/session-create/ui/SessionCreatePage.tsx
@@ -25,7 +25,7 @@ import { createRoom } from "@/shared/api/room";
 import { fetchSlidesMeta, fetchAllOriginalSlideUrls } from "@/shared/api/presentation";
 import websocketService from "@/shared/api/websocket";
 import { useBroadcastPublisher, useBroadcastReactionVisibility } from "@/shared/lib/broadcast";
-import { uploadFonts, finalizeUpload } from "@/shared/api/pdfFonts";
+import { useFontMutations } from "../model/useFontMutations";
 import FontRequirementPrompt from "./FontRequirementPrompt";
 import type { ChunkUploadReady, FontReportEntry } from "@/shared/api/model/pdf";
 
@@ -44,8 +44,6 @@ const PresentationPrepPage = () => {
   const [restoredSlides, setRestoredSlides] = useState<(string | null)[] | null>(null);
   const [fatalMessage, setFatalMessage] = useState<string | null>(null);
   const [pendingFonts, setPendingFonts] = useState<{ uploadId: string; fontReport: FontReportEntry[] } | null>(null);
-  const [fontBusy, setFontBusy] = useState(false);
-  const [uploadingName, setUploadingName] = useState<string | null>(null);
   const [fontWarnings, setFontWarnings] = useState<Record<string, string>>({});
   const [fontError, setFontError] = useState<string | null>(null);
   const pendingRoomRef = useRef<any>(null);
@@ -353,71 +351,56 @@ const PresentationPrepPage = () => {
     [navigate, roomIdParam, location.state]
   );
 
-  // 개별 폰트를 업로드해 서버에 등록하고, 갱신된 리포트로 배지를 바꾼다(변환은 하지 않음).
-  const handleUploadFont = useCallback(
-    async (fontName: string, file: File) => {
-      if (!pendingFonts) return;
-      setUploadingName(fontName);
+  // 폰트 업로드 / 변환 시작은 React Query mutation 으로 처리한다(청크 업로드는 raw axios 유지).
+  const { uploadFont, finalize: runFinalize, uploadingName, busy: fontBusy } = useFontMutations({
+    onUploaded: (fontName, res) => {
       setFontError(null);
-      try {
-        const res = await uploadFonts(pendingFonts.uploadId, [file], fontName);
-        // 서버는 전체 리포트를 재분석하지 않으므로, 일치하면 해당 폰트만 로컬에서 '사용 가능'으로 바꾼다.
-        if (res.matched) {
-          setPendingFonts((prev) =>
-            prev
-              ? {
-                  ...prev,
-                  fontReport: prev.fontReport.map((e) =>
-                    e.name === fontName ? { ...e, status: "AVAILABLE" as const, installed: true } : e
-                  ),
-                }
-              : prev
-          );
-          setFontWarnings((prev) => {
-            const next = { ...prev };
-            delete next[fontName];
-            return next;
-          });
-        } else {
-          setFontWarnings((prev) => ({ ...prev, [fontName]: res.uploadedFamilies?.[0] ?? "" }));
-        }
-      } catch {
-        setFontError("폰트 업로드에 실패했습니다. 다시 시도해주세요.");
-      } finally {
-        setUploadingName(null);
+      // 서버는 전체 리포트를 재분석하지 않으므로, 일치하면 해당 폰트만 로컬에서 '사용 가능'으로 바꾼다.
+      if (res.matched) {
+        setPendingFonts((prev) =>
+          prev
+            ? {
+                ...prev,
+                fontReport: prev.fontReport.map((e) =>
+                  e.name === fontName ? { ...e, status: "AVAILABLE" as const, installed: true } : e
+                ),
+              }
+            : prev
+        );
+        setFontWarnings((prev) => {
+          const next = { ...prev };
+          delete next[fontName];
+          return next;
+        });
+      } else {
+        setFontWarnings((prev) => ({ ...prev, [fontName]: res.uploadedFamilies?.[0] ?? "" }));
       }
     },
-    [pendingFonts]
+    onUploadError: () => setFontError("폰트 업로드에 실패했습니다. 다시 시도해주세요."),
+    onFinalized: (ready) => applyReady(pendingRoomRef.current, ready),
+    onFinalizeError: () => setFontError("변환을 시작하지 못했습니다. 다시 시도해주세요."),
+  });
+
+  const handleUploadFont = useCallback(
+    (fontName: string, file: File) => {
+      if (!pendingFonts) return;
+      setFontError(null);
+      uploadFont(pendingFonts.uploadId, fontName, file);
+    },
+    [pendingFonts, uploadFont]
   );
 
-  const handleProceedWithout = useCallback(async () => {
+  const handleContinue = useCallback(() => {
     if (!pendingFonts) return;
-    setFontBusy(true);
     setFontError(null);
-    try {
-      const ready = await finalizeUpload(pendingFonts.uploadId, true);
-      applyReady(pendingRoomRef.current, ready);
-    } catch {
-      setFontError("변환을 시작하지 못했습니다. 다시 시도해주세요.");
-    } finally {
-      setFontBusy(false);
-    }
-  }, [pendingFonts, applyReady]);
+    runFinalize(pendingFonts.uploadId, false);
+  }, [pendingFonts, runFinalize]);
 
-  // 업로드한 폰트로 변환을 시작한다(finalize).
-  const handleContinue = useCallback(async () => {
+  const handleProceedWithout = useCallback(() => {
     if (!pendingFonts) return;
-    setFontBusy(true);
     setFontError(null);
-    try {
-      const ready = await finalizeUpload(pendingFonts.uploadId, false);
-      applyReady(pendingRoomRef.current, ready);
-    } catch {
-      setFontError("변환을 시작하지 못했습니다. 다시 시도해주세요.");
-    } finally {
-      setFontBusy(false);
-    }
-  }, [pendingFonts, applyReady]);
+    runFinalize(pendingFonts.uploadId, true);
+  }, [pendingFonts, runFinalize]);
 
   // 신규 업로드 플로우: createRoom → 청크 업로드 → SSE 스트림 구독
   useEffect(() => {

--- a/src/pages/session-create/ui/SessionCreatePage.tsx
+++ b/src/pages/session-create/ui/SessionCreatePage.tsx
@@ -343,7 +343,13 @@ const PresentationPrepPage = () => {
         // BE 는 totalPages >= 1 을 요구하므로 placeholder 로 1 을 보낸다.
         // 실제 총 페이지는 업로드 조립 완료 응답(ready.totalPages) 에서 확정된다.
         const room = await createRoom(1);
-        const ready = await uploadPdf(sourceFile, room.roomId, room.deckId);
+        const terminal = await uploadPdf(sourceFile, room.roomId, room.deckId);
+        // NEEDS_FONTS 분기(폰트 업로드 프롬프트)는 별도 작업에서 연결 예정이므로,
+        // 현재는 READY 가 아니면 업로드 실패로 처리한다.
+        if (terminal.status !== "READY") {
+          throw new Error("이 발표 자료에 필요한 폰트가 서버에 없습니다.");
+        }
+        const ready = terminal;
 
         const nextRoomData = {
           ...room,

--- a/src/shared/api/model/pdf.ts
+++ b/src/shared/api/model/pdf.ts
@@ -25,6 +25,8 @@ export interface FontReportEntry {
   status: FontStatus;
   embedded: boolean;
   installed: boolean;
+  // 누락 폰트를 업로드 없이 변환할 때 서버가 실제로 사용할 대체 폰트(fc-match). 알 수 없으면 null.
+  substitute?: string | null;
 }
 
 // 청크 업로드 완료, 단, 누락 폰트 존재 (HTTP 201, status=NEEDS_FONTS)

--- a/src/shared/api/model/pdf.ts
+++ b/src/shared/api/model/pdf.ts
@@ -18,7 +18,28 @@ export interface ChunkUploadReady {
   streamUrl: string;
 }
 
-export type ChunkUploadResult = ChunkUploadInProgress | ChunkUploadReady;
+export type FontStatus = 'AVAILABLE' | 'MISSING';
+
+export interface FontReportEntry {
+  name: string;
+  status: FontStatus;
+  embedded: boolean;
+  installed: boolean;
+}
+
+// 청크 업로드 완료, 단, 누락 폰트 존재 (HTTP 201, status=NEEDS_FONTS)
+export interface ChunkUploadNeedsFonts {
+  status: 'NEEDS_FONTS';
+  uploadId: string;
+  fontReport: FontReportEntry[];
+}
+
+export type ChunkUploadTerminal = ChunkUploadReady | ChunkUploadNeedsFonts;
+
+export type ChunkUploadResult =
+  | ChunkUploadInProgress
+  | ChunkUploadReady
+  | ChunkUploadNeedsFonts;
 
 // SSE: event=page
 export interface SsePageEvent {

--- a/src/shared/api/model/pdf.ts
+++ b/src/shared/api/model/pdf.ts
@@ -36,6 +36,16 @@ export interface ChunkUploadNeedsFonts {
   fontReport: FontReportEntry[];
 }
 
+// POST /api/upload/{uploadId}/fonts 응답
+export interface FontUploadResponse {
+  report: FontReportEntry[];
+  // targetFont 를 함께 보낸 경우, 방금 올린 파일이 그 요구 폰트와 실제로 일치하는지. 아니면 null/undefined.
+  matched?: boolean | null;
+  targetFont?: string | null;
+  // 방금 올린 파일들의 내부 패밀리명(사용자에게 무엇이 올라갔는지 보여주기 위함)
+  uploadedFamilies?: string[];
+}
+
 export type ChunkUploadTerminal = ChunkUploadReady | ChunkUploadNeedsFonts;
 
 export type ChunkUploadResult =

--- a/src/shared/api/model/pdf.ts
+++ b/src/shared/api/model/pdf.ts
@@ -36,9 +36,8 @@ export interface ChunkUploadNeedsFonts {
   fontReport: FontReportEntry[];
 }
 
-// POST /api/upload/{uploadId}/fonts 응답
+// POST /api/upload/{uploadId}/fonts 응답 (개별 폰트 검증 — 전체 리포트는 돌려주지 않는다)
 export interface FontUploadResponse {
-  report: FontReportEntry[];
   // targetFont 를 함께 보낸 경우, 방금 올린 파일이 그 요구 폰트와 실제로 일치하는지. 아니면 null/undefined.
   matched?: boolean | null;
   targetFont?: string | null;

--- a/src/shared/api/pdfFonts.ts
+++ b/src/shared/api/pdfFonts.ts
@@ -1,0 +1,17 @@
+import api from './api';
+import type { ChunkUploadReady, FontReportEntry } from './model/pdf';
+
+export async function uploadFonts(uploadId: string, files: File[]): Promise<FontReportEntry[]> {
+  const form = new FormData();
+  files.forEach((f) => form.append('fonts', f));
+  const res = await api.post(`/api/upload/${uploadId}/fonts`, form);
+  return res.data.data as FontReportEntry[];
+}
+
+export async function finalizeUpload(
+  uploadId: string,
+  proceedWithoutFonts = false,
+): Promise<ChunkUploadReady> {
+  const res = await api.post(`/api/upload/${uploadId}/finalize`, { proceedWithoutFonts });
+  return res.data.data as ChunkUploadReady;
+}

--- a/src/shared/api/pdfFonts.ts
+++ b/src/shared/api/pdfFonts.ts
@@ -1,11 +1,16 @@
 import api from './api';
-import type { ChunkUploadReady, FontReportEntry } from './model/pdf';
+import type { ChunkUploadReady, FontUploadResponse } from './model/pdf';
 
-export async function uploadFonts(uploadId: string, files: File[]): Promise<FontReportEntry[]> {
+export async function uploadFonts(
+  uploadId: string,
+  files: File[],
+  targetFont?: string,
+): Promise<FontUploadResponse> {
   const form = new FormData();
   files.forEach((f) => form.append('fonts', f));
+  if (targetFont) form.append('targetFont', targetFont);
   const res = await api.post(`/api/upload/${uploadId}/fonts`, form);
-  return res.data.data as FontReportEntry[];
+  return res.data.data as FontUploadResponse;
 }
 
 export async function finalizeUpload(

--- a/src/shared/api/pdfUpload.ts
+++ b/src/shared/api/pdfUpload.ts
@@ -1,8 +1,8 @@
 import { v4 as uuidv4 } from 'uuid';
 import api from './api';
 import type {
-  ChunkUploadReady,
   ChunkUploadResult,
+  ChunkUploadTerminal,
 } from './model/pdf';
 
 // 2MB 고정 (백엔드 스펙)
@@ -57,7 +57,7 @@ interface UploadOptions {
 export async function uploadPdfInChunks(
   file: File,
   opts: UploadOptions,
-): Promise<ChunkUploadReady> {
+): Promise<ChunkUploadTerminal> {
   const uploadId = uuidv4();
   const totalChunks = Math.max(1, Math.ceil(file.size / CHUNK_SIZE));
   const concurrency = Math.min(opts.concurrency ?? DEFAULT_CONCURRENCY, totalChunks);
@@ -108,11 +108,12 @@ export async function uploadPdfInChunks(
     opts.signal?.removeEventListener('abort', onExternalAbort);
   }
 
-  const ready = results.find(
-    (r): r is ChunkUploadReady => !!r && r.status === 'READY',
+  const terminal = results.find(
+    (r): r is ChunkUploadTerminal =>
+      !!r && (r.status === 'READY' || r.status === 'NEEDS_FONTS'),
   );
-  if (!ready) {
-    throw new Error('청크 업로드가 완료되었지만 READY 응답을 받지 못했습니다.');
+  if (!terminal) {
+    throw new Error('청크 업로드가 완료되었지만 종료 응답(READY/NEEDS_FONTS)을 받지 못했습니다.');
   }
-  return ready;
+  return terminal;
 }

--- a/tests/unit/FontRequirementPrompt.test.tsx
+++ b/tests/unit/FontRequirementPrompt.test.tsx
@@ -55,14 +55,29 @@ describe("FontRequirementPrompt", () => {
     expect(screen.getByRole("button", { name: "업로드 중…" })).toBeInTheDocument();
   });
 
-  it("fires onContinue and onProceedWithout", () => {
+  it("confirms before continuing when fonts are still missing", () => {
     const onContinue = vi.fn();
-    const onProceedWithout = vi.fn();
-    renderPrompt({ onContinue, onProceedWithout });
-
+    renderPrompt({ onContinue }); // 기본 report 에 MISSING 폰트가 있음
     fireEvent.click(screen.getByRole("button", { name: "변환 시작" }));
-    fireEvent.click(screen.getByRole("button", { name: "그냥 진행" }));
+    expect(onContinue).not.toHaveBeenCalled(); // 바로 진행하지 않고 확인 모달을 띄운다
+    fireEvent.click(screen.getByRole("button", { name: "네, 시작할게요" }));
     expect(onContinue).toHaveBeenCalledOnce();
+  });
+
+  it("continues immediately when nothing is missing", () => {
+    const onContinue = vi.fn();
+    renderPrompt({
+      fontReport: [{ name: "Arial", status: "AVAILABLE", embedded: false, installed: true }],
+      onContinue,
+    });
+    fireEvent.click(screen.getByRole("button", { name: "변환 시작" }));
+    expect(onContinue).toHaveBeenCalledOnce();
+  });
+
+  it("fires onProceedWithout", () => {
+    const onProceedWithout = vi.fn();
+    renderPrompt({ onProceedWithout });
+    fireEvent.click(screen.getByRole("button", { name: "그냥 진행" }));
     expect(onProceedWithout).toHaveBeenCalledOnce();
   });
 

--- a/tests/unit/FontRequirementPrompt.test.tsx
+++ b/tests/unit/FontRequirementPrompt.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import type { ComponentProps } from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import FontRequirementPrompt from "@/pages/session-create/ui/FontRequirementPrompt";
 
@@ -7,77 +8,67 @@ const report = [
   { name: "Arial", status: "AVAILABLE" as const, embedded: false, installed: true },
 ];
 
+function renderPrompt(overrides: Partial<ComponentProps<typeof FontRequirementPrompt>> = {}) {
+  const props = {
+    fontReport: report,
+    busy: false,
+    uploadingName: null,
+    error: null,
+    onUploadFont: () => {},
+    onContinue: () => {},
+    onProceedWithout: () => {},
+    ...overrides,
+  };
+  return { props, ...render(<FontRequirementPrompt {...props} />) };
+}
+
 describe("FontRequirementPrompt", () => {
   it("lists fonts with status", () => {
-    render(
-      <FontRequirementPrompt
-        fontReport={report}
-        busy={false}
-        error={null}
-        onCheckFonts={() => {}}
-        onUploadFonts={() => {}}
-        onProceedWithout={() => {}}
-      />
-    );
+    renderPrompt();
     expect(screen.getByText("Malgun Gothic")).toBeInTheDocument();
     expect(screen.getByText("Arial")).toBeInTheDocument();
   });
 
-  it("fires onProceedWithout", () => {
-    const onProceed = vi.fn();
-    render(
-      <FontRequirementPrompt
-        fontReport={report}
-        busy={false}
-        error={null}
-        onCheckFonts={() => {}}
-        onUploadFonts={() => {}}
-        onProceedWithout={onProceed}
-      />
-    );
-    fireEvent.click(screen.getByRole("button", { name: "그냥 진행" }));
-    expect(onProceed).toHaveBeenCalledOnce();
+  it("shows an upload button only on missing rows", () => {
+    renderPrompt();
+    // Only Malgun Gothic (MISSING) has an upload button; Arial (AVAILABLE) does not.
+    expect(screen.getAllByRole("button", { name: "업로드" })).toHaveLength(1);
   });
 
-  it("re-check button is disabled until files are picked, then fires onCheckFonts with them", () => {
-    const onCheck = vi.fn();
-    const { container } = render(
-      <FontRequirementPrompt
-        fontReport={report}
-        busy={false}
-        error={null}
-        onCheckFonts={onCheck}
-        onUploadFonts={() => {}}
-        onProceedWithout={() => {}}
-      />
-    );
+  it("uploads a file for the specific font row", () => {
+    const onUploadFont = vi.fn();
+    const { container } = renderPrompt({ onUploadFont });
 
-    const checkBtn = screen.getByRole("button", { name: "선택한 폰트로 다시 확인" });
-    expect(checkBtn).toBeDisabled();
-
+    fireEvent.click(screen.getByRole("button", { name: "업로드" }));
     const input = container.querySelector('input[type="file"]') as HTMLInputElement;
-    const file = new File([new Uint8Array([1, 2, 3])], "MyFont.ttf");
+    const file = new File([new Uint8Array([1, 2, 3])], "malgun.ttf");
     fireEvent.change(input, { target: { files: [file] } });
 
-    expect(checkBtn).not.toBeDisabled();
-    fireEvent.click(checkBtn);
-    expect(onCheck).toHaveBeenCalledTimes(1);
-    expect(onCheck.mock.calls[0][0]).toHaveLength(1);
-    expect(onCheck.mock.calls[0][0][0].name).toBe("MyFont.ttf");
+    expect(onUploadFont).toHaveBeenCalledTimes(1);
+    expect(onUploadFont.mock.calls[0][0]).toBe("Malgun Gothic");
+    expect(onUploadFont.mock.calls[0][1].name).toBe("malgun.ttf");
+  });
+
+  it("shows an uploading state on the row being uploaded", () => {
+    renderPrompt({ uploadingName: "Malgun Gothic" });
+    expect(screen.getByRole("button", { name: "업로드 중…" })).toBeInTheDocument();
+  });
+
+  it("fires onContinue and onProceedWithout", () => {
+    const onContinue = vi.fn();
+    const onProceedWithout = vi.fn();
+    renderPrompt({ onContinue, onProceedWithout });
+
+    fireEvent.click(screen.getByRole("button", { name: "변환 시작" }));
+    fireEvent.click(screen.getByRole("button", { name: "그냥 진행" }));
+    expect(onContinue).toHaveBeenCalledOnce();
+    expect(onProceedWithout).toHaveBeenCalledOnce();
   });
 
   it("shows an all-resolved message when nothing is missing", () => {
-    const resolved = [{ name: "Arial", status: "AVAILABLE" as const, embedded: false, installed: true }];
-    render(
-      <FontRequirementPrompt
-        fontReport={resolved}
-        busy={false}
-        error={null}
-        onCheckFonts={() => {}}
-        onUploadFonts={() => {}}
-        onProceedWithout={() => {}}
-      />
-    );
+    renderPrompt({
+      fontReport: [{ name: "Arial", status: "AVAILABLE", embedded: false, installed: true }],
+    });
     expect(screen.getByText(/모두 준비되었어요/)).toBeInTheDocument();
   });
 });

--- a/tests/unit/FontRequirementPrompt.test.tsx
+++ b/tests/unit/FontRequirementPrompt.test.tsx
@@ -14,6 +14,7 @@ describe("FontRequirementPrompt", () => {
         fontReport={report}
         busy={false}
         error={null}
+        onCheckFonts={() => {}}
         onUploadFonts={() => {}}
         onProceedWithout={() => {}}
       />
@@ -29,11 +30,54 @@ describe("FontRequirementPrompt", () => {
         fontReport={report}
         busy={false}
         error={null}
+        onCheckFonts={() => {}}
         onUploadFonts={() => {}}
         onProceedWithout={onProceed}
       />
     );
     fireEvent.click(screen.getByRole("button", { name: "그냥 진행" }));
     expect(onProceed).toHaveBeenCalledOnce();
+  });
+
+  it("re-check button is disabled until files are picked, then fires onCheckFonts with them", () => {
+    const onCheck = vi.fn();
+    const { container } = render(
+      <FontRequirementPrompt
+        fontReport={report}
+        busy={false}
+        error={null}
+        onCheckFonts={onCheck}
+        onUploadFonts={() => {}}
+        onProceedWithout={() => {}}
+      />
+    );
+
+    const checkBtn = screen.getByRole("button", { name: "선택한 폰트로 다시 확인" });
+    expect(checkBtn).toBeDisabled();
+
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File([new Uint8Array([1, 2, 3])], "MyFont.ttf");
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(checkBtn).not.toBeDisabled();
+    fireEvent.click(checkBtn);
+    expect(onCheck).toHaveBeenCalledTimes(1);
+    expect(onCheck.mock.calls[0][0]).toHaveLength(1);
+    expect(onCheck.mock.calls[0][0][0].name).toBe("MyFont.ttf");
+  });
+
+  it("shows an all-resolved message when nothing is missing", () => {
+    const resolved = [{ name: "Arial", status: "AVAILABLE" as const, embedded: false, installed: true }];
+    render(
+      <FontRequirementPrompt
+        fontReport={resolved}
+        busy={false}
+        error={null}
+        onCheckFonts={() => {}}
+        onUploadFonts={() => {}}
+        onProceedWithout={() => {}}
+      />
+    );
+    expect(screen.getByText(/모든 폰트가 준비되었어요/)).toBeInTheDocument();
   });
 });

--- a/tests/unit/FontRequirementPrompt.test.tsx
+++ b/tests/unit/FontRequirementPrompt.test.tsx
@@ -78,6 +78,6 @@ describe("FontRequirementPrompt", () => {
         onProceedWithout={() => {}}
       />
     );
-    expect(screen.getByText(/모든 폰트가 준비되었어요/)).toBeInTheDocument();
+    expect(screen.getByText(/모두 준비되었어요/)).toBeInTheDocument();
   });
 });

--- a/tests/unit/FontRequirementPrompt.test.tsx
+++ b/tests/unit/FontRequirementPrompt.test.tsx
@@ -13,6 +13,7 @@ function renderPrompt(overrides: Partial<ComponentProps<typeof FontRequirementPr
     fontReport: report,
     busy: false,
     uploadingName: null,
+    warnings: {},
     error: null,
     onUploadFont: () => {},
     onContinue: () => {},
@@ -70,5 +71,10 @@ describe("FontRequirementPrompt", () => {
       fontReport: [{ name: "Arial", status: "AVAILABLE", embedded: false, installed: true }],
     });
     expect(screen.getByText(/모두 준비되었어요/)).toBeInTheDocument();
+  });
+
+  it("shows a mismatch warning when the uploaded file did not match the font", () => {
+    renderPrompt({ warnings: { "Malgun Gothic": "Yoon Mokryn" } });
+    expect(screen.getByText(/올린 폰트: Yoon Mokryn/)).toBeInTheDocument();
   });
 });

--- a/tests/unit/FontRequirementPrompt.test.tsx
+++ b/tests/unit/FontRequirementPrompt.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import FontRequirementPrompt from "@/pages/session-create/ui/FontRequirementPrompt";
+
+const report = [
+  { name: "Malgun Gothic", status: "MISSING" as const, embedded: false, installed: false },
+  { name: "Arial", status: "AVAILABLE" as const, embedded: false, installed: true },
+];
+
+describe("FontRequirementPrompt", () => {
+  it("lists fonts with status", () => {
+    render(
+      <FontRequirementPrompt
+        fontReport={report}
+        busy={false}
+        error={null}
+        onUploadFonts={() => {}}
+        onProceedWithout={() => {}}
+      />
+    );
+    expect(screen.getByText("Malgun Gothic")).toBeInTheDocument();
+    expect(screen.getByText("Arial")).toBeInTheDocument();
+  });
+
+  it("fires onProceedWithout", () => {
+    const onProceed = vi.fn();
+    render(
+      <FontRequirementPrompt
+        fontReport={report}
+        busy={false}
+        error={null}
+        onUploadFonts={() => {}}
+        onProceedWithout={onProceed}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "그냥 진행" }));
+    expect(onProceed).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/pdf-model.test.ts
+++ b/tests/unit/pdf-model.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import type { ChunkUploadTerminal } from "@/shared/api/model/pdf";
+
+describe("ChunkUploadTerminal", () => {
+  it("narrows on status", () => {
+    const r: ChunkUploadTerminal = {
+      status: "NEEDS_FONTS",
+      uploadId: "u1",
+      fontReport: [{ name: "Malgun Gothic", status: "MISSING", embedded: false, installed: false }],
+    };
+    expect(r.status === "NEEDS_FONTS" ? r.fontReport.length : 0).toBe(1);
+  });
+});

--- a/tests/unit/pdfFonts.test.ts
+++ b/tests/unit/pdfFonts.test.ts
@@ -8,15 +8,24 @@ import { uploadFonts, finalizeUpload } from "@/shared/api/pdfFonts";
 describe("pdfFonts", () => {
   beforeEach(() => post.mockReset());
 
-  it("posts fonts as multipart and returns report", async () => {
+  it("posts fonts with targetFont as multipart and returns the upload result", async () => {
     post.mockResolvedValue({
-      data: { data: [{ name: "Arial", status: "AVAILABLE", embedded: false, installed: true }] },
+      data: {
+        data: {
+          report: [{ name: "Arial", status: "AVAILABLE", embedded: false, installed: true }],
+          matched: true,
+          targetFont: "Arial",
+          uploadedFamilies: ["Arial"],
+        },
+      },
     });
-    const report = await uploadFonts("u1", [new File([new Uint8Array(1)], "a.ttf")]);
-    expect(report[0].name).toBe("Arial");
+    const res = await uploadFonts("u1", [new File([new Uint8Array(1)], "a.ttf")], "Arial");
+    expect(res.report[0].name).toBe("Arial");
+    expect(res.matched).toBe(true);
     const [url, body] = post.mock.calls[0];
     expect(url).toBe("/api/upload/u1/fonts");
     expect(body).toBeInstanceOf(FormData);
+    expect((body as FormData).get("targetFont")).toBe("Arial");
   });
 
   it("finalizes and returns READY", async () => {

--- a/tests/unit/pdfFonts.test.ts
+++ b/tests/unit/pdfFonts.test.ts
@@ -8,20 +8,13 @@ import { uploadFonts, finalizeUpload } from "@/shared/api/pdfFonts";
 describe("pdfFonts", () => {
   beforeEach(() => post.mockReset());
 
-  it("posts fonts with targetFont as multipart and returns the upload result", async () => {
+  it("posts fonts with targetFont as multipart and returns the match result", async () => {
     post.mockResolvedValue({
-      data: {
-        data: {
-          report: [{ name: "Arial", status: "AVAILABLE", embedded: false, installed: true }],
-          matched: true,
-          targetFont: "Arial",
-          uploadedFamilies: ["Arial"],
-        },
-      },
+      data: { data: { matched: true, targetFont: "Arial", uploadedFamilies: ["Arial"] } },
     });
     const res = await uploadFonts("u1", [new File([new Uint8Array(1)], "a.ttf")], "Arial");
-    expect(res.report[0].name).toBe("Arial");
     expect(res.matched).toBe(true);
+    expect(res.uploadedFamilies?.[0]).toBe("Arial");
     const [url, body] = post.mock.calls[0];
     expect(url).toBe("/api/upload/u1/fonts");
     expect(body).toBeInstanceOf(FormData);

--- a/tests/unit/pdfFonts.test.ts
+++ b/tests/unit/pdfFonts.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { post } = vi.hoisted(() => ({ post: vi.fn() }));
+vi.mock("@/shared/api/api", () => ({ default: { post } }));
+
+import { uploadFonts, finalizeUpload } from "@/shared/api/pdfFonts";
+
+describe("pdfFonts", () => {
+  beforeEach(() => post.mockReset());
+
+  it("posts fonts as multipart and returns report", async () => {
+    post.mockResolvedValue({
+      data: { data: [{ name: "Arial", status: "AVAILABLE", embedded: false, installed: true }] },
+    });
+    const report = await uploadFonts("u1", [new File([new Uint8Array(1)], "a.ttf")]);
+    expect(report[0].name).toBe("Arial");
+    const [url, body] = post.mock.calls[0];
+    expect(url).toBe("/api/upload/u1/fonts");
+    expect(body).toBeInstanceOf(FormData);
+  });
+
+  it("finalizes and returns READY", async () => {
+    post.mockResolvedValue({
+      data: {
+        data: {
+          status: "READY",
+          uploadId: "u1",
+          pdfId: "p",
+          fileName: "f",
+          totalPages: 3,
+          streamUrl: "/s",
+        },
+      },
+    });
+    const ready = await finalizeUpload("u1", true);
+    expect(ready.status).toBe("READY");
+    const [url, body] = post.mock.calls[0];
+    expect(url).toBe("/api/upload/u1/finalize");
+    expect(body).toEqual({ proceedWithoutFonts: true });
+  });
+});

--- a/tests/unit/pdfUpload.test.ts
+++ b/tests/unit/pdfUpload.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { post } = vi.hoisted(() => ({ post: vi.fn() }));
+vi.mock("@/shared/api/api", () => ({ default: { post } }));
+
+import { uploadPdfInChunks } from "@/shared/api/pdfUpload";
+
+describe("uploadPdfInChunks", () => {
+  beforeEach(() => post.mockReset());
+
+  it("returns NEEDS_FONTS terminal result", async () => {
+    post.mockResolvedValue({
+      status: 201,
+      data: { data: { status: "NEEDS_FONTS", uploadId: "u1", fontReport: [] } },
+    });
+    const file = new File([new Uint8Array(10)], "deck.pptx");
+    const result = await uploadPdfInChunks(file, { roomId: "r", deckId: "d" });
+    expect(result.status).toBe("NEEDS_FONTS");
+  });
+});


### PR DESCRIPTION
## ✨ 작업 개요

PPTX 업로드 시 백엔드가 "덱에 사용됐지만 서버에 없는 폰트"를 감지하면(`NEEDS_FONTS`), 발표자에게 폰트 업로드를 요청하는 모달(`FontRequirementPrompt`)을 **슬라이드 로딩 화면 위에** 띄우고, 폰트를 올려 그 폰트로 변환을 진행하도록 하는 세션 생성(`session-create`) 플로우입니다.

## ✅ 주요 작업 내용

- **`FontRequirementPrompt` 모달 구현** — 앱 디자인 시스템(`SessionWarningModal` 톤: 스크림 · 라운드 카드 · 마스코트 · 버튼)을 재사용. 필요한(누락) 폰트 목록 + 상태 칩, **각 폰트별 개별 `업로드` 버튼**, 서버가 실제로 쓸 대체 폰트 표시, 업로드 가능한 파일 조건(형식 · 파일당 15MB · 전체 60MB) 스펙 표.
- **API 연동** — `shared/api/pdfFonts.ts`(`uploadFonts` / `finalizeUpload`) 추가. 폰트 업로드 · 변환 시작을 **React Query mutation**(`pages/session-create/model/useFontMutations.ts`)으로 처리 — 기존 `usePdfDownloadPolicy` 컨벤션과 동일. (청크 업로드는 기존 raw axios 병렬 로직 유지)
- **업로드 플로우(A/B 페이징)** — 마지막 청크 응답이 `NEEDS_FONTS` 면 SSE 스트림 대신 모달 표시. 개별 폰트 업로드 시 `targetFont` 일치 여부를 서버에서 가볍게 검증해 **해당 행만** 즉시 '사용 가능'으로 갱신, 불일치 시 경고(`올린 폰트: …`). `변환 시작`(finalize) 시 **모달을 닫고 '발표 자료 준비 중' 로딩 화면**을 보여준 뒤 기존 슬라이드 스트리밍으로 복귀.
- **UX 디테일** — 누락 폰트가 남아있는데 `변환 시작` 하면 확인 모달, 폰트 목록 **항상 노출되는 얇은 스크롤바** + 하단 그라데이션(스크롤 유도).
- **타입 / 테스트** — `shared/api/model/pdf.ts` 에 `NEEDS_FONTS` · `FontUploadResponse` 타입, `pdfUpload` 터미널 유니온(`READY | NEEDS_FONTS`), `tests/unit` 에 관련 유닛 테스트 추가.

## 🔄 관련 이슈

- 관련 이슈 없음 (기능 신규 추가)

## 📸 스크린샷 (선택)

> 폰트 업로드 모달(슬라이드 로딩 화면 위) — 스크린샷 첨부 예정

## 📝 비고

- **백엔드 의존**: 이 기능은 백엔드 폰트 감지/업로드 API(`NEEDS_FONTS`, `POST /api/upload/{uploadId}/fonts`, `/finalize`)가 있어야 동작합니다. → 백엔드 PR: `likelion-line4thon-crushers/BE#103`
- 폰트 매칭은 **파일명이 아니라 폰트 내부 family 이름** 기준입니다. 내부 이름이 덱이 부르는 이름과 다르면 불일치로 표시될 수 있어요(정상 동작).
- 추후(v2 후보): 강제 폰트 스왑(A 폰트 → B 폰트 지정), 새로고침 중 세션 복구.
