### PR TITLE
refactor(session-create): 업로드 플로우 재구성 — 아톰 파일 전달, 페이즈 머신, 새로고침 복구

### DIFF
--- a/src/app/PresenterRoomGate.tsx
+++ b/src/app/PresenterRoomGate.tsx
@@ -1,10 +1,10 @@
 import { useLayoutEffect, useRef } from "react";
 import { useLocation, useParams } from "react-router";
-import { useAtom } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import { SessionCreatePage } from "@/pages/session-create";
 import { PresenterRoomPage } from "@/pages/presenter-room";
 import { SessionLoadingOverlay } from "@/shared/ui/session-loading-overlay";
-import { presenterModeAtom } from "@/entities/room";
+import { presenterModeAtom, pendingPresentationFileAtom } from "@/entities/room";
 import type { PresenterMode } from "@/entities/room";
 import { getSessionStatus } from "@/shared/api/room";
 import { sessionStartMarker } from "@/shared/config/storage-keys";
@@ -21,7 +21,7 @@ import { sessionStartMarker } from "@/shared/config/storage-keys";
  *
  * 동기 판정(첫 렌더에서 즉시 결정 — 백엔드 조회 불필요):
  *  - roomId 없음(/rooms/new) → 준비
- *  - 업로드 직후(location.state.roomData/pdfFile) → 준비
+ *  - 업로드 진행/직후(pendingPresentationFileAtom 또는 location.state.roomData) → 준비
  *  - 시작 마커 보유(발표자 본인의 새로고침) → 발표
  *  - 그 외 → null(미정) → 로딩 + 백엔드 조회
  */
@@ -29,12 +29,11 @@ const PresenterRoomGate = () => {
   const { roomId } = useParams();
   const location = useLocation();
   const [mode, setMode] = useAtom(presenterModeAtom);
+  const pendingFile = useAtomValue(pendingPresentationFileAtom);
   const decidedRoomRef = useRef<string | null>(null);
 
-  const locationState = (location.state as any) || {};
-  const hasUploadState = Boolean(
-    locationState.roomData || locationState.pdfFile || locationState.presentationFile
-  );
+  const locationState = (location.state as { roomData?: unknown } | null) ?? {};
+  const hasUploadState = Boolean(pendingFile || locationState.roomData);
 
   // 첫 렌더에 동기적으로 결정 가능한 값. null 이면 백엔드 조회가 필요하다.
   // ⚠️ 시작 마커를 업로드 상태보다 먼저 본다. location.state(roomData)는 history.state 에

--- a/src/entities/room/index.ts
+++ b/src/entities/room/index.ts
@@ -1,4 +1,10 @@
 export type { RoomData, JoinRoomResponse, SessionStatus, RoomInfo } from "./model/room";
+export { pendingPresentationFileAtom } from "./model/pendingUpload";
+export {
+  persistRoomData,
+  readPersistedRoomData,
+  clearPersistedRoomData,
+} from "./model/persistedRoom";
 export {
   roomIdAtom,
   deckIdAtom,

--- a/src/entities/room/model/pendingUpload.ts
+++ b/src/entities/room/model/pendingUpload.ts
@@ -1,0 +1,8 @@
+import { atom } from "jotai";
+
+/**
+ * 랜딩에서 선택한 발표 파일. File 은 직렬화가 불가능해 location.state 로 나르면
+ * 새로고침/브라우저별 동작 차이에 취약하므로 아톰으로 전달한다.
+ * 새로고침 시 자연히 유실되며, 그 경우 SessionCreatePage 가 업로드 중단 안내를 띄운다.
+ */
+export const pendingPresentationFileAtom = atom<File | null>(null);

--- a/src/entities/room/model/persistedRoom.ts
+++ b/src/entities/room/model/persistedRoom.ts
@@ -1,0 +1,35 @@
+import { STORAGE_KEYS } from "@/shared/config/storage-keys";
+import type { RoomData } from "./room";
+
+/**
+ * 발표자 roomData 의 sessionStorage 영속화 헬퍼.
+ * totalPages <= 0 인 데이터는 "방은 만들었지만 업로드가 끝나지 않은" 스켈레톤을 뜻한다
+ * (SessionCreatePage 가 이 마커로 중단된 업로드를 감지한다).
+ */
+export function persistRoomData(data: RoomData) {
+  try {
+    sessionStorage.setItem(STORAGE_KEYS.ROOM, JSON.stringify(data));
+  } catch {
+    /* ignore */
+  }
+}
+
+export function readPersistedRoomData(): RoomData | null {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEYS.ROOM);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || !("roomId" in parsed)) return null;
+    return parsed as RoomData;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPersistedRoomData() {
+  try {
+    sessionStorage.removeItem(STORAGE_KEYS.ROOM);
+  } catch {
+    /* ignore */
+  }
+}

--- a/src/pages/landing/ui/LandingPage.tsx
+++ b/src/pages/landing/ui/LandingPage.tsx
@@ -2,6 +2,9 @@ import React, { useState } from "react";
 import { useNavigate } from "react-router";
 import styled, { css } from "styled-components";
 import { usePostHog } from "@posthog/react";
+import { useSetAtom } from "jotai";
+import { pendingPresentationFileAtom } from "@/entities/room";
+import { MAX_PRESENTATION_FILE_BYTES, MAX_PRESENTATION_FILE_LABEL } from "@/shared/config/upload";
 import TitleSVG from "@/shared/assets/images/title.svg";
 import Emoji1 from "@/shared/assets/images/emoji1.svg";
 import Emoji2 from "@/shared/assets/images/emoji2.svg";
@@ -191,6 +194,15 @@ const HiddenInput = styled.input`
   display: none;
 `;
 
+const ErrorText = styled.p`
+  margin: 0.6vh 0 0;
+  color: #d32f2f;
+  font-size: clamp(12px, 0.9vw, 15px);
+  font-weight: 600;
+  text-align: center;
+  word-break: keep-all;
+`;
+
 const Button = styled.button`
   padding: 1.3vh 1.8vw;
   background-color: ${(props) => (props.disabled ? "#ccc" : "#e8541e")};
@@ -207,8 +219,10 @@ const Button = styled.button`
 
 const MainPage = () => {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [fileError, setFileError] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const navigate = useNavigate();
+  const setPendingFile = useSetAtom(pendingPresentationFileAtom);
   const posthog = usePostHog();
 
   // 클릭 선택과 드래그 앤 드롭이 완전히 같은 검증/계측 경로를 타도록 단일화.
@@ -217,13 +231,23 @@ const MainPage = () => {
       file_type: getPresentationFileType(file),
       ...(viaDragDrop ? { via_drag_drop: true } : {}),
     };
-    if (isSupportedPresentationFile(file)) {
-      setSelectedFile(file);
-      posthog?.capture(ANALYTICS_EVENTS.PRESENTATION_FILE_SELECTED, props);
-    } else {
-      posthog?.capture(ANALYTICS_EVENTS.PRESENTATION_FILE_REJECTED, props);
-      alert("PDF, PPT, PPTX 파일만 선택해주세요!");
+    if (!isSupportedPresentationFile(file)) {
+      posthog?.capture(ANALYTICS_EVENTS.PRESENTATION_FILE_REJECTED, { ...props, reason: "type" });
+      setFileError("PDF, PPT, PPTX 파일만 선택할 수 있어요.");
+      return;
     }
+    if (file.size > MAX_PRESENTATION_FILE_BYTES) {
+      posthog?.capture(ANALYTICS_EVENTS.PRESENTATION_FILE_REJECTED, {
+        ...props,
+        reason: "size",
+        file_size_bytes: file.size,
+      });
+      setFileError(`파일이 너무 커요. ${MAX_PRESENTATION_FILE_LABEL} 이하만 업로드할 수 있어요.`);
+      return;
+    }
+    setSelectedFile(file);
+    setFileError(null);
+    posthog?.capture(ANALYTICS_EVENTS.PRESENTATION_FILE_SELECTED, props);
   };
 
   const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -238,17 +262,16 @@ const MainPage = () => {
   };
 
   const handleStartPresentation = () => {
-    if (!selectedFile) return alert("발표 자료를 먼저 업로드해주세요!");
+    if (!selectedFile) {
+      setFileError("발표 자료를 먼저 업로드해주세요!");
+      return;
+    }
     posthog?.capture(ANALYTICS_EVENTS.PRESENTATION_STARTED, {
       file_type: getPresentationFileType(selectedFile),
     });
-    navigate("/rooms/new", {
-      state: {
-        presentationFile: selectedFile,
-        pdfFile: selectedFile,
-        fileName: selectedFile.name,
-      },
-    });
+    // File 은 직렬화가 안 되므로 location.state 대신 아톰으로 전달한다.
+    setPendingFile(selectedFile);
+    navigate("/rooms/new", { state: { fileName: selectedFile.name } });
   };
 
   return (
@@ -288,6 +311,15 @@ const MainPage = () => {
             }}
             onDrop={handleDrop}
             onClick={() => (document.getElementById("pdfInput") as HTMLInputElement)?.click()}
+            role="button"
+            tabIndex={0}
+            aria-label="발표 자료 파일 선택 (PDF, PPT, PPTX)"
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                (document.getElementById("pdfInput") as HTMLInputElement)?.click();
+              }
+            }}
           >
             <span className="file-name">
               {selectedFile
@@ -306,6 +338,8 @@ const MainPage = () => {
               ➜
             </span>
           </UploadBox>
+
+          {fileError && <ErrorText role="alert">{fileError}</ErrorText>}
 
           <HiddenInput
             id="pdfInput"

--- a/src/pages/presenter-room/ui/PresenterRoomPage.tsx
+++ b/src/pages/presenter-room/ui/PresenterRoomPage.tsx
@@ -3,6 +3,7 @@ import type { ChangeEvent } from "react";
 import { useLocation, useParams } from "react-router";
 import { usePostHog } from "@posthog/react";
 import { ANALYTICS_EVENTS, ANALYTICS_GROUP_SESSION } from "@/shared/config/analytics-events";
+import { STORAGE_KEYS } from "@/shared/config/storage-keys";
 import {
   PresentationLayout,
   SlideViewer,
@@ -62,10 +63,22 @@ const PresenterRoomPage = () => {
   const { roomId: roomIdParam } = useParams();
   const posthog = usePostHog();
 
-  const storedRoomData = useMemo(
-    () => JSON.parse(sessionStorage.getItem("boini_room") || "{}"),
-    []
-  );
+  // sessionStorage 를 우선하되(항상 최신), 준비 페이지가 남긴 history.state 의
+  // roomData 를 폴백으로 병합한다 (스토리지 쓰기 실패 대비).
+  const storedRoomData = useMemo(() => {
+    const stateRoomData = (location.state as { roomData?: Record<string, unknown> } | null)
+      ?.roomData;
+    let stored: Record<string, unknown> = {};
+    try {
+      stored = JSON.parse(sessionStorage.getItem(STORAGE_KEYS.ROOM) || "{}");
+    } catch {
+      stored = {};
+    }
+    return {
+      ...(stateRoomData && typeof stateRoomData === "object" ? stateRoomData : {}),
+      ...stored,
+    };
+  }, [location.state]);
 
   const locationState = location.state || {};
 

--- a/src/pages/session-create/model/resolvePresenterRoomData.ts
+++ b/src/pages/session-create/model/resolvePresenterRoomData.ts
@@ -1,74 +1,30 @@
-type PresenterRoomData = {
-  roomId?: string | number;
-  deckId?: string | null;
-  [key: string]: unknown;
-};
+import type { RoomData } from "@/entities/room";
+import { readPersistedRoomData } from "@/entities/room";
 
-type LocationState = {
-  roomData?: PresenterRoomData | null;
-  roomId?: string | number;
-  deckId?: string | null;
-  [key: string]: unknown;
+/** 발표자 플로우에서 location.state 로 전달되는 값 (직렬화 가능한 것만). */
+export type PresenterLocationState = {
+  roomData?: RoomData | null;
+  fileName?: string;
 } | null;
 
-const toRoomData = (value: unknown): PresenterRoomData | null => {
-  if (!value || typeof value !== "object") {
-    return null;
-  }
-
-  return value as PresenterRoomData;
-};
-
-// roomIdParam 이 없으면(= /rooms/new 신규 업로드 진입) stale sessionStorage 값을 채택하지 않도록 false 반환.
-// 이전 구현은 true 를 돌려 이전 세션의 roomData 가 신규 플로우로 흘러들어 upload effect 를 skip 시키고,
-// canStartSession/totalPages 를 오염시켰다.
-const roomIdsMatch = (storedRoomId: PresenterRoomData["roomId"], roomIdParam?: string) => {
-  if (!roomIdParam) {
-    return false;
-  }
-
-  if (storedRoomId == null) {
-    return false;
-  }
-
+// roomIdParam 이 없으면(= /rooms/new 신규 업로드 진입) stale sessionStorage 값을 채택하지
+// 않도록 false 반환. 이전 세션의 roomData 가 신규 플로우로 흘러들면 업로드를 skip 시키고
+// canStartSession/totalPages 를 오염시킨다.
+const roomIdsMatch = (storedRoomId: RoomData["roomId"] | undefined, roomIdParam?: string) => {
+  if (!roomIdParam || storedRoomId == null) return false;
   return String(storedRoomId) === String(roomIdParam);
 };
 
 export const resolvePresenterRoomData = (
   roomIdParam?: string,
-  locationState?: LocationState
-): PresenterRoomData | null => {
-  const locationRoomData = toRoomData(locationState?.roomData);
-  if (locationRoomData && roomIdsMatch(locationRoomData.roomId, roomIdParam)) {
-    return locationRoomData;
-  }
+  locationState?: unknown
+): RoomData | null => {
+  const state = (locationState ?? null) as PresenterLocationState;
+  const fromState = state?.roomData ?? null;
+  if (fromState && roomIdsMatch(fromState.roomId, roomIdParam)) return fromState;
 
-  if (
-    locationState?.roomId &&
-    locationState?.deckId &&
-    roomIdsMatch(locationState.roomId, roomIdParam)
-  ) {
-    return {
-      ...locationState,
-      roomId: locationState.roomId,
-      deckId: locationState.deckId,
-    };
-  }
+  const stored = readPersistedRoomData();
+  if (stored && roomIdsMatch(stored.roomId, roomIdParam)) return stored;
 
-  try {
-    const stored = sessionStorage.getItem("boini_room");
-    if (!stored) {
-      return null;
-    }
-
-    const parsed = JSON.parse(stored);
-    const storedRoomData = toRoomData(parsed);
-    if (!storedRoomData || !roomIdsMatch(storedRoomData.roomId, roomIdParam)) {
-      return null;
-    }
-
-    return storedRoomData;
-  } catch {
-    return null;
-  }
+  return null;
 };

--- a/src/pages/session-create/model/usePdfStream.ts
+++ b/src/pages/session-create/model/usePdfStream.ts
@@ -1,6 +1,6 @@
-import { useEffect, useRef, useState } from 'react';
-import type { SseErrorEvent, SsePageEvent } from '@/shared/api/model/pdf';
-import { subscribePdfStream } from '@/shared/api/pdfStream';
+import { useEffect, useState } from "react";
+import type { SseErrorEvent, SsePageEvent } from "@/shared/api/model/pdf";
+import { subscribePdfStream } from "@/shared/api/pdfStream";
 
 interface UsePdfStreamArgs {
   streamUrl: string | null;
@@ -15,7 +15,9 @@ export function usePdfStream({ streamUrl, totalPages, enabled }: UsePdfStreamArg
   const [canStartSession, setCanStartSession] = useState(false);
   const [done, setDone] = useState(false);
   const [fatalError, setFatalError] = useState<SseErrorEvent | Error | null>(null);
-  const pageErrorsRef = useRef<Record<number, SseErrorEvent>>({});
+  // 페이지 단위 렌더링 실패 — 스트림은 계속되지만 해당 페이지는 빈 슬라이드로 남는다.
+  // UI 에서 "N장 변환 실패" 안내를 띄울 수 있도록 상태로 노출한다.
+  const [pageErrors, setPageErrors] = useState<Record<number, SseErrorEvent>>({});
 
   useEffect(() => {
     if (!enabled || !streamUrl || totalPages <= 0) return;
@@ -24,7 +26,7 @@ export function usePdfStream({ streamUrl, totalPages, enabled }: UsePdfStreamArg
     setCanStartSession(false);
     setDone(false);
     setFatalError(null);
-    pageErrorsRef.current = {};
+    setPageErrors({});
 
     const close = subscribePdfStream({
       streamUrl,
@@ -50,12 +52,12 @@ export function usePdfStream({ streamUrl, totalPages, enabled }: UsePdfStreamArg
           return;
         }
         // PDF 자체 열기 실패 → 스트림 종료, 치명 오류
-        if (e.pageIndex === -1 || e.code === 'PDF_LOAD_FAILED') {
+        if (e.pageIndex === -1 || e.code === "PDF_LOAD_FAILED") {
           setFatalError(e);
           return;
         }
         // 페이지 단위 실패 → 기록만 하고 스트림 지속
-        pageErrorsRef.current[e.pageIndex] = e;
+        setPageErrors((prev) => ({ ...prev, [e.pageIndex]: e }));
       },
     });
 
@@ -67,6 +69,6 @@ export function usePdfStream({ streamUrl, totalPages, enabled }: UsePdfStreamArg
     canStartSession,
     done,
     fatalError,
-    pageErrors: pageErrorsRef.current,
+    pageErrors,
   };
 }

--- a/src/pages/session-create/model/usePresentationUploadFlow.ts
+++ b/src/pages/session-create/model/usePresentationUploadFlow.ts
@@ -1,0 +1,238 @@
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import { createLogger } from "@/shared/lib/logger";
+import type { RoomData } from "@/entities/room";
+import { createRoom } from "@/shared/api/room";
+import { getUploadErrorMessage } from "@/shared/api/uploadError";
+import type { ChunkUploadReady, FontReportEntry } from "@/shared/api/model/pdf";
+import { useChunkedPdfUpload } from "./useChunkedPdfUpload";
+import { useFontMutations } from "./useFontMutations";
+
+const log = createLogger("upload-flow");
+
+export type UploadFlowPhase =
+  | { step: "idle" }
+  | { step: "creating-room" }
+  | { step: "uploading" }
+  | { step: "awaiting-fonts"; uploadId: string; fontReport: FontReportEntry[] }
+  | { step: "done" }
+  | { step: "failed"; message: string };
+
+type FlowAction =
+  | { type: "START" }
+  | { type: "ROOM_CREATED" }
+  | { type: "NEEDS_FONTS"; uploadId: string; fontReport: FontReportEntry[] }
+  | { type: "FONT_MATCHED"; fontName: string }
+  | { type: "DONE" }
+  | { type: "FAIL"; message: string }
+  | { type: "RESET" };
+
+function reducer(phase: UploadFlowPhase, action: FlowAction): UploadFlowPhase {
+  switch (action.type) {
+    case "START":
+      return { step: "creating-room" };
+    case "ROOM_CREATED":
+      return { step: "uploading" };
+    case "NEEDS_FONTS":
+      return { step: "awaiting-fonts", uploadId: action.uploadId, fontReport: action.fontReport };
+    case "FONT_MATCHED":
+      // 서버는 전체 리포트를 재분석하지 않으므로, 일치한 폰트만 로컬에서 '사용 가능'으로 바꾼다.
+      if (phase.step !== "awaiting-fonts") return phase;
+      return {
+        ...phase,
+        fontReport: phase.fontReport.map((e) =>
+          e.name === action.fontName ? { ...e, status: "AVAILABLE" as const, installed: true } : e
+        ),
+      };
+    case "DONE":
+      return { step: "done" };
+    case "FAIL":
+      return { step: "failed", message: action.message };
+    case "RESET":
+      return { step: "idle" };
+  }
+}
+
+interface Params {
+  /** 랜딩에서 넘어온 발표 파일. 값이 생기면 자동으로 플로우를 시작한다. */
+  pendingFile: File | null;
+  /** 방 생성 직후 — 캐노니컬 URL 로 교체하고 스켈레톤 roomData 를 영속화할 기회. */
+  onRoomCreated: (room: RoomData) => void;
+  /** 업로드/변환 확정 — SSE 구독을 시작할 수 있는 시점. */
+  onReady: (room: RoomData, ready: ChunkUploadReady) => void;
+  /** 신규 플로우 시작 직전 — 이전 세션 잔재(atom/스토리지/로컬 state) 리셋. */
+  onStart: () => void;
+}
+
+/**
+ * 발표 자료 업로드 파이프라인 오케스트레이터.
+ * createRoom → 청크 업로드 → (폰트 확인) → finalize 를 명시적 단계 머신으로 관리한다.
+ *
+ * - 언마운트/StrictMode 재실행 시 진행 중 요청을 abort 하고, 재실행이면 처음부터 다시 시작한다.
+ * - 재시도(retry)는 이미 만든 방을 재사용하되 uploadId 는 새로 발급된다
+ *   (서버 청크 카운터는 수신 횟수 기반이라 같은 uploadId 로 청크를 재전송하면 안 된다).
+ */
+export function usePresentationUploadFlow({
+  pendingFile,
+  onRoomCreated,
+  onReady,
+  onStart,
+}: Params) {
+  const [phase, dispatch] = useReducer(reducer, { step: "idle" });
+  const { upload: uploadPdf, progress } = useChunkedPdfUpload();
+
+  const roomRef = useRef<RoomData | null>(null);
+  const controllerRef = useRef<AbortController | null>(null);
+  const startedForRef = useRef<File | null>(null);
+
+  // 콜백은 latest-ref 로 보관해 run 의 정체성을 안정시킨다 (effect 재실행 → 업로드 중단 방지).
+  const callbacksRef = useRef({ onRoomCreated, onReady, onStart });
+  useEffect(() => {
+    callbacksRef.current = { onRoomCreated, onReady, onStart };
+  }, [onRoomCreated, onReady, onStart]);
+
+  const [fontWarnings, setFontWarnings] = useState<Record<string, string>>({});
+  const [fontError, setFontError] = useState<string | null>(null);
+
+  const {
+    uploadFont: mutateFontUpload,
+    finalize,
+    uploadingName,
+    busy: fontBusy,
+  } = useFontMutations({
+    onUploaded: (fontName, res) => {
+      setFontError(null);
+      if (res.matched) {
+        dispatch({ type: "FONT_MATCHED", fontName });
+        setFontWarnings((prev) => {
+          const next = { ...prev };
+          delete next[fontName];
+          return next;
+        });
+      } else {
+        setFontWarnings((prev) => ({ ...prev, [fontName]: res.uploadedFamilies?.[0] ?? "" }));
+      }
+    },
+    onUploadError: () => setFontError("폰트 업로드에 실패했습니다. 다시 시도해주세요."),
+    onFinalized: (ready) => {
+      const room = roomRef.current;
+      if (!room) return;
+      dispatch({ type: "DONE" });
+      callbacksRef.current.onReady(room, ready);
+    },
+    onFinalizeError: () => setFontError("변환을 시작하지 못했습니다. 다시 시도해주세요."),
+  });
+
+  const run = useCallback(
+    async (file: File, signal: AbortSignal) => {
+      dispatch({ type: "START" });
+      callbacksRef.current.onStart();
+      setFontWarnings({});
+      setFontError(null);
+      try {
+        let room = roomRef.current;
+        if (!room) {
+          // BE 는 totalPages >= 1 을 요구하므로 placeholder 로 1 을 보낸다.
+          // 실제 총 페이지는 업로드 조립 완료 응답(ready.totalPages)에서 확정된다.
+          const created = await createRoom(1, signal);
+          // abort 확인을 roomRef 할당보다 먼저 — 중단된 run 이 다른 run 의 방을 덮어쓰지 않도록.
+          if (signal.aborted) return;
+          room = created;
+          roomRef.current = created;
+          callbacksRef.current.onRoomCreated(created);
+        }
+        if (signal.aborted) return;
+
+        dispatch({ type: "ROOM_CREATED" });
+        const terminal = await uploadPdf(file, room.roomId, room.deckId, signal);
+        if (terminal.status === "NEEDS_FONTS") {
+          dispatch({
+            type: "NEEDS_FONTS",
+            uploadId: terminal.uploadId,
+            fontReport: terminal.fontReport,
+          });
+          return; // finalize 는 사용자 액션(폰트 업로드 / 그냥 진행)으로 트리거된다
+        }
+
+        dispatch({ type: "DONE" });
+        callbacksRef.current.onReady(room, terminal);
+      } catch (err) {
+        if (signal.aborted) return; // 취소는 실패로 취급하지 않는다
+        log.error("발표 자료 업로드 실패:", err);
+        dispatch({
+          type: "FAIL",
+          message: getUploadErrorMessage(
+            err,
+            "발표 자료 업로드에 실패했습니다. 다시 시도해주세요."
+          ),
+        });
+      }
+    },
+    [uploadPdf]
+  );
+
+  // 자동 시작: pendingFile 이 생기면 한 번 실행. cleanup 은 StrictMode 재실행과
+  // 실제 언마운트 양쪽에서 진행 중 요청을 중단하고 가드를 풀어 재시작을 허용한다.
+  useEffect(() => {
+    if (!pendingFile || startedForRef.current === pendingFile) return undefined;
+    startedForRef.current = pendingFile;
+    const controller = new AbortController();
+    controllerRef.current = controller;
+    void run(pendingFile, controller.signal);
+    return () => {
+      // ref 를 통해 최신 컨트롤러를 abort — retry() 가 교체한 컨트롤러도 언마운트 시 중단되도록.
+      controllerRef.current?.abort();
+      startedForRef.current = null;
+    };
+  }, [pendingFile, run]);
+
+  const retry = useCallback(() => {
+    const file = startedForRef.current ?? pendingFile;
+    if (!file) return;
+    startedForRef.current = file;
+    const controller = new AbortController();
+    controllerRef.current = controller;
+    void run(file, controller.signal);
+  }, [pendingFile, run]);
+
+  const cancel = useCallback(() => {
+    controllerRef.current?.abort();
+    dispatch({ type: "RESET" });
+  }, []);
+
+  const uploadFont = useCallback(
+    (fontName: string, file: File) => {
+      if (phase.step !== "awaiting-fonts") return;
+      setFontError(null);
+      mutateFontUpload(phase.uploadId, fontName, file);
+    },
+    [phase, mutateFontUpload]
+  );
+
+  const continueWithFonts = useCallback(() => {
+    if (phase.step !== "awaiting-fonts") return;
+    setFontError(null);
+    finalize(phase.uploadId, false);
+  }, [phase, finalize]);
+
+  const proceedWithoutFonts = useCallback(() => {
+    if (phase.step !== "awaiting-fonts") return;
+    setFontError(null);
+    finalize(phase.uploadId, true);
+  }, [phase, finalize]);
+
+  return {
+    phase,
+    progress,
+    retry,
+    cancel,
+    fonts: {
+      warnings: fontWarnings,
+      error: fontError,
+      uploadingName,
+      busy: fontBusy,
+      uploadFont,
+      continueWithFonts,
+      proceedWithoutFonts,
+    },
+  };
+}

--- a/src/pages/session-create/model/useRestorePresenterSlides.ts
+++ b/src/pages/session-create/model/useRestorePresenterSlides.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createLogger } from "@/shared/lib/logger";
+import { fetchSlidesMeta, fetchAllOriginalSlideUrls } from "@/shared/api/presentation";
+
+const log = createLogger("session-restore");
+
+export type RestoreOutcome =
+  | { kind: "slides"; slides: (string | null)[]; totalPages: number }
+  | { kind: "resubscribe"; streamUrl: string; totalPages: number }
+  | { kind: "failed" };
+
+interface Params {
+  enabled: boolean;
+  roomId?: string | null;
+  deckId?: string | null;
+  totalPages?: number;
+  pdfId?: string | null;
+}
+
+/**
+ * 새로고침 복원: sessionStorage 의 roomData 로 재진입했을 때 슬라이드를 되살린다.
+ * 우선순위:
+ *  1) meta 엔드포인트로 모든 페이지 URL 이 완비돼 있으면 slides 로 고정 표시.
+ *  2) meta 가 부분만 반환하거나 실패 + pdfId 가 있으면 SSE 스트림 재구독
+ *     (BE 는 subscribe 시점 이전 이벤트를 버퍼링 후 flush 해주므로 안전).
+ *  3) 둘 다 불가하면 레거시 per-page API 로 마지막 폴백, 그것도 실패하면 failed.
+ */
+export function useRestorePresenterSlides({ enabled, roomId, deckId, totalPages, pdfId }: Params) {
+  const [outcome, setOutcome] = useState<RestoreOutcome | null>(null);
+  const [attempt, setAttempt] = useState(0);
+  const startedKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const pages = totalPages ?? 0;
+    if (!enabled || !roomId || !deckId || pages <= 0) return undefined;
+
+    const key = `${roomId}:${deckId}:${attempt}`;
+    if (startedKeyRef.current === key) return undefined;
+    startedKeyRef.current = key;
+
+    let cancelled = false;
+
+    const resubscribe = (): boolean => {
+      if (!pdfId) return false;
+      setOutcome({ kind: "resubscribe", streamUrl: `/api/pdf/${pdfId}/stream`, totalPages: pages });
+      return true;
+    };
+
+    const restore = async () => {
+      try {
+        const urls = await fetchSlidesMeta(roomId, deckId, pages);
+        if (cancelled) return;
+        const allReady = urls.length === pages && urls.every((u) => !!u);
+        if (allReady) {
+          setOutcome({ kind: "slides", slides: urls, totalPages: pages });
+          return;
+        }
+        // meta 가 부분만 반환 → BE 가 아직 렌더링 중. SSE 로 재구독해 남은 페이지 수신.
+        if (resubscribe()) {
+          log.warn("meta 부분 응답, SSE 재구독으로 전환");
+          return;
+        }
+        throw new Error("meta 응답이 비어 있음");
+      } catch (metaErr) {
+        if (cancelled) return;
+        log.warn("meta 조회 실패:", metaErr);
+        if (resubscribe()) return;
+        // 최후 폴백: 레거시 per-page API
+        try {
+          const urls = await fetchAllOriginalSlideUrls(roomId, deckId, pages);
+          if (cancelled) return;
+          setOutcome({ kind: "slides", slides: urls, totalPages: pages });
+        } catch (err) {
+          if (cancelled) return;
+          log.error("슬라이드 복원 실패:", err);
+          setOutcome({ kind: "failed" });
+        }
+      }
+    };
+
+    restore();
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, roomId, deckId, totalPages, pdfId, attempt]);
+
+  const retry = useCallback(() => {
+    setOutcome(null);
+    setAttempt((n) => n + 1);
+  }, []);
+
+  return { outcome, retry };
+}

--- a/src/pages/session-create/model/useRollingMessage.ts
+++ b/src/pages/session-create/model/useRollingMessage.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+
+/**
+ * 시간 경과에 따라 로딩 메시지를 순차적으로 넘긴다 (마지막 메시지에서 유지).
+ * 청크 업로드는 서버 응답 기준이라 실제 진행률 신호가 없으므로,
+ * 멈춰 보이지 않도록 메시지를 굴리는 것으로 대체한다.
+ */
+export function useRollingMessage(
+  messages: readonly string[],
+  active: boolean,
+  intervalMs = 4000
+): string {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    if (!active) {
+      setIndex(0);
+      return undefined;
+    }
+    const timer = setInterval(() => {
+      setIndex((i) => Math.min(i + 1, messages.length - 1));
+    }, intervalMs);
+    return () => clearInterval(timer);
+  }, [active, intervalMs, messages.length]);
+
+  return messages[Math.min(index, messages.length - 1)];
+}

--- a/src/pages/session-create/ui/RenderFailureBanner.styles.ts
+++ b/src/pages/session-create/ui/RenderFailureBanner.styles.ts
@@ -1,0 +1,34 @@
+import styled from "styled-components";
+
+export const Banner = styled.div`
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-radius: 10px;
+  background: #303030;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+  word-break: keep-all;
+`;
+
+export const DismissButton = styled.button`
+  border: none;
+  background: transparent;
+  color: #b0b0b0;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 2px;
+
+  &:hover {
+    color: #fff;
+  }
+`;

--- a/src/pages/session-create/ui/RenderFailureBanner.tsx
+++ b/src/pages/session-create/ui/RenderFailureBanner.tsx
@@ -1,0 +1,18 @@
+import { Banner, DismissButton } from "./RenderFailureBanner.styles";
+
+interface RenderFailureBannerProps {
+  failedCount: number;
+  onDismiss: () => void;
+}
+
+/** SSE 페이지 단위 렌더링 실패 안내 — 실패한 페이지는 빈 슬라이드로 남는다. */
+const RenderFailureBanner = ({ failedCount, onDismiss }: RenderFailureBannerProps) => (
+  <Banner role="status">
+    슬라이드 {failedCount}장을 변환하지 못했습니다. 해당 페이지는 비어 보일 수 있어요.
+    <DismissButton type="button" onClick={onDismiss} aria-label="알림 닫기">
+      ✕
+    </DismissButton>
+  </Banner>
+);
+
+export default RenderFailureBanner;

--- a/src/pages/session-create/ui/SessionCreatePage.styles.ts
+++ b/src/pages/session-create/ui/SessionCreatePage.styles.ts
@@ -1,0 +1,18 @@
+import styled from "styled-components";
+
+export const UploadCancelButton = styled.button`
+  padding: 8px 20px;
+  border: 1px solid #d9d9d9;
+  border-radius: 8px;
+  background: transparent;
+  color: #5c5c5c;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: 0.2s;
+
+  &:hover {
+    border-color: #b0b0b0;
+    color: #303030;
+  }
+`;

--- a/src/pages/session-create/ui/SessionCreatePage.tsx
+++ b/src/pages/session-create/ui/SessionCreatePage.tsx
@@ -1,8 +1,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import type { KeyboardEvent } from "react";
 import { useLocation, useNavigate, useParams } from "react-router";
-import { useSetAtom } from "jotai";
-import { createLogger } from "@/shared/lib/logger";
+import { useAtom, useSetAtom } from "jotai";
 import { SessionLoadingOverlay } from "@/shared/ui/session-loading-overlay";
 import {
   PresentationLayout,
@@ -14,39 +13,48 @@ import {
 } from "@/widgets/presentation-layout";
 import { SlidesSidebar } from "@/widgets/slides-sidebar";
 import { useQuickSettingsStorage, usePdfDownloadPolicy } from "@/entities/session";
-import { canStartSessionAtom } from "@/entities/room";
+import {
+  canStartSessionAtom,
+  pendingPresentationFileAtom,
+  persistRoomData,
+  clearPersistedRoomData,
+} from "@/entities/room";
+import type { RoomData } from "@/entities/room";
 import { SlideNotesPanel, usePresenterSlideNotes } from "@/entities/slide-note";
 import { storageKeys } from "@/shared/config/storage-keys";
 import { DEFAULT_AUDIENCE_CAPACITY } from "@/shared/config/audience";
-import { useChunkedPdfUpload } from "../model/useChunkedPdfUpload";
-import { usePdfStream } from "../model/usePdfStream";
-import { resolvePresenterRoomData } from "../model/resolvePresenterRoomData";
-import { createRoom } from "@/shared/api/room";
-import { fetchSlidesMeta, fetchAllOriginalSlideUrls } from "@/shared/api/presentation";
 import websocketService from "@/shared/api/websocket";
 import { useBroadcastPublisher, useBroadcastReactionVisibility } from "@/shared/lib/broadcast";
-import { useFontMutations } from "../model/useFontMutations";
+import type { ChunkUploadReady } from "@/shared/api/model/pdf";
+import { usePresentationUploadFlow } from "../model/usePresentationUploadFlow";
+import { usePdfStream } from "../model/usePdfStream";
+import { useRestorePresenterSlides } from "../model/useRestorePresenterSlides";
+import { useRollingMessage } from "../model/useRollingMessage";
+import { resolvePresenterRoomData } from "../model/resolvePresenterRoomData";
 import FontRequirementPrompt from "./FontRequirementPrompt";
-import type { ChunkUploadReady, FontReportEntry } from "@/shared/api/model/pdf";
+import UploadErrorPanel from "./UploadErrorPanel";
+import RenderFailureBanner from "./RenderFailureBanner";
+import { UploadCancelButton } from "./SessionCreatePage.styles";
 
-const log = createLogger("session-create");
+// 청크 업로드는 실제 진행률 신호가 없어(마지막 응답이 서버 변환까지 블로킹) 시간 기반으로 굴린다.
+const UPLOAD_MESSAGES = [
+  "발표 자료 업로드 중...",
+  "슬라이드로 변환하는 중...",
+  "슬라이드를 준비하는 중...",
+  "거의 다 됐어요...",
+] as const;
 
 const PresentationPrepPage = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const { roomId: roomIdParam } = useParams();
-  const { presentationFile, pdfFile } = location.state || {};
-  const sourceFile = presentationFile || pdfFile;
+  const [pendingFile, setPendingFile] = useAtom(pendingPresentationFileAtom);
   const initialRoomData = resolvePresenterRoomData(roomIdParam, location.state);
 
   const [currentSlide, setCurrentSlide] = useState(0);
-  const [roomData, setRoomData] = useState<any>(initialRoomData);
-  const [restoredSlides, setRestoredSlides] = useState<(string | null)[] | null>(null);
+  const [roomData, setRoomData] = useState<RoomData | null>(initialRoomData);
   const [fatalMessage, setFatalMessage] = useState<string | null>(null);
-  const [pendingFonts, setPendingFonts] = useState<{ uploadId: string; fontReport: FontReportEntry[] } | null>(null);
-  const [fontWarnings, setFontWarnings] = useState<Record<string, string>>({});
-  const [fontError, setFontError] = useState<string | null>(null);
-  const pendingRoomRef = useRef<any>(null);
+  const [renderFailureDismissed, setRenderFailureDismissed] = useState(false);
 
   const roomId = useMemo(() => roomIdParam || roomData?.roomId || null, [roomIdParam, roomData]);
   const quickSettingsStorageKey = roomId ? storageKeys.quickSettings(String(roomId)) : null;
@@ -64,7 +72,6 @@ const PresentationPrepPage = () => {
       typeof roomData?.pdfDownloadEnabled === "boolean" ? roomData.pdfDownloadEnabled : undefined,
   });
 
-  const hasInitializedRef = useRef(false);
   const pendingQuickSettingsRef = useRef<any>({
     sticker: quickSettings.sticker,
     question: quickSettings.question,
@@ -107,26 +114,123 @@ const PresentationPrepPage = () => {
     pendingUnlockRef.current = quickSettings.unlock;
   }, [quickSettings]);
 
-  const { upload: uploadPdf, progress: uploadProgress } = useChunkedPdfUpload();
-
   // 업로드 & 스트림 상태
   const [streamUrl, setStreamUrl] = useState<string | null>(null);
   const [totalPages, setTotalPages] = useState<number>(
     typeof initialRoomData?.totalPages === "number" ? initialRoomData.totalPages : 0
   );
 
+  const setCanStartSessionAtomValue = useSetAtom(canStartSessionAtom);
+
+  // ── 신규 업로드 파이프라인 (createRoom → 청크 업로드 → 폰트 확인 → SSE) ──
+  const handleFlowStart = useCallback(() => {
+    // 신규 업로드 진입 — 이전 세션 잔재(atom, sessionStorage, 로컬 state)를 모두 리셋.
+    setCanStartSessionAtomValue(false);
+    clearPersistedRoomData();
+    setTotalPages(0);
+    setStreamUrl(null);
+    setRoomData(null);
+  }, [setCanStartSessionAtomValue]);
+
+  const handleRoomCreated = useCallback(
+    (room: RoomData) => {
+      // totalPages 0 = "방은 있지만 업로드 미완료" 마커. 새로고침 시 중단 안내에 사용된다.
+      const skeleton: RoomData = { ...room, totalPages: 0 };
+      setRoomData(skeleton);
+      persistRoomData(skeleton);
+      // 방이 생기는 즉시 캐노니컬 URL 로 교체 — 업로드 중 새로고침해도 /rooms/:roomId 로 복귀.
+      navigate(`/rooms/${room.roomId}`, {
+        replace: true,
+        state: { roomData: skeleton, fileName: pendingFile?.name },
+      });
+    },
+    [navigate, pendingFile]
+  );
+
+  const handleReady = useCallback(
+    (room: RoomData, ready: ChunkUploadReady) => {
+      const next: RoomData = {
+        ...room,
+        totalPages: ready.totalPages,
+        pdfId: ready.pdfId,
+        fileName: ready.fileName,
+        canStartSession: false,
+        pdfDownloadEnabled: false,
+      };
+      setRoomData(next);
+      setTotalPages(ready.totalPages);
+      setStreamUrl(ready.streamUrl);
+      persistRoomData(next);
+      setPendingFile(null); // 성공 — 원본 File 참조 해제
+      // 같은 URL 로 replace 해 history.state 의 roomData 를 완성본으로 갱신한다
+      // (발표 화면 전환/새로고침 시 sessionStorage 유실에 대한 이중화).
+      navigate(`/rooms/${room.roomId}`, {
+        replace: true,
+        state: { roomData: next, fileName: next.fileName },
+      });
+    },
+    [setPendingFile, navigate]
+  );
+
+  const {
+    phase,
+    retry: retryUpload,
+    cancel: cancelUpload,
+    fonts,
+  } = usePresentationUploadFlow({
+    pendingFile,
+    onStart: handleFlowStart,
+    onRoomCreated: handleRoomCreated,
+    onReady: handleReady,
+  });
+
+  const isUploadOverlayActive = phase.step === "creating-room" || phase.step === "uploading";
+  const uploadMessage = useRollingMessage(UPLOAD_MESSAGES, isUploadOverlayActive);
+
+  // ── 새로고침 복원 (업로드 완료 이후 재진입) ──
+  const { outcome: restoreOutcome, retry: retryRestore } = useRestorePresenterSlides({
+    enabled: !pendingFile && phase.step === "idle",
+    roomId: roomData?.roomId,
+    deckId: roomData?.deckId,
+    totalPages: roomData?.totalPages,
+    pdfId: roomData?.pdfId,
+  });
+  const restoredSlides = restoreOutcome?.kind === "slides" ? restoreOutcome.slides : null;
+
+  useEffect(() => {
+    if (!restoreOutcome || restoreOutcome.kind === "failed") return;
+    setTotalPages(restoreOutcome.totalPages);
+    if (restoreOutcome.kind === "resubscribe") setStreamUrl(restoreOutcome.streamUrl);
+  }, [restoreOutcome]);
+
+  // 방은 만들어졌지만 업로드가 끝나기 전에 이탈/새로고침한 경우 (원본 File 유실)
+  const uploadInterrupted =
+    !pendingFile && phase.step === "idle" && !!roomData?.roomId && (roomData.totalPages ?? 0) <= 0;
+
+  // 업로드 파일도, 복원할 roomData 도 없으면 이 페이지에 올 이유가 없다 → 랜딩으로
+  useEffect(() => {
+    if (pendingFile || roomData?.roomId || phase.step !== "idle") return;
+    navigate("/");
+  }, [pendingFile, roomData?.roomId, phase.step, navigate]);
+
+  const goHome = useCallback(() => {
+    cancelUpload();
+    setPendingFile(null);
+    clearPersistedRoomData();
+    setCanStartSessionAtomValue(false);
+    navigate("/");
+  }, [cancelUpload, setPendingFile, setCanStartSessionAtomValue, navigate]);
+
   const {
     slides: streamedSlides,
     canStartSession,
-    done: streamDone,
     fatalError,
+    pageErrors,
   } = usePdfStream({
     streamUrl,
     totalPages,
     enabled: !!streamUrl && totalPages > 0,
   });
-
-  const setCanStartSessionAtomValue = useSetAtom(canStartSessionAtom);
 
   const handleOptionChange = useCallback(
     (optionKey: any, value: any) => {
@@ -177,14 +281,10 @@ const PresentationPrepPage = () => {
       const savedEnabled = await setPdfDownloadPolicyEnabled(enabled);
       if (typeof savedEnabled !== "boolean") return;
 
-      setRoomData((prev: any) => {
+      setRoomData((prev) => {
         if (!prev || prev.pdfDownloadEnabled === savedEnabled) return prev;
         const next = { ...prev, pdfDownloadEnabled: savedEnabled };
-        try {
-          sessionStorage.setItem("boini_room", JSON.stringify(next));
-        } catch {
-          /* ignore */
-        }
+        persistRoomData(next);
         return next;
       });
     },
@@ -254,215 +354,6 @@ const PresentationPrepPage = () => {
     }
   }, [isPresenterWsReady, roomId]);
 
-  // 새로고침 복원: sessionStorage 에 roomData 가 있고 pdfFile 이 없을 때.
-  // 우선순위:
-  //  1) meta 엔드포인트로 모든 페이지 URL 이 완비돼 있으면 restoredSlides 로 고정 표시.
-  //  2) meta 가 부분만 돌려주거나 실패 + pdfId 가 있으면 SSE 스트림을 재구독해서 남은 페이지를 수신.
-  //     (BE 는 subscribe 시점 이전 이벤트를 버퍼링 후 flush 해주므로 안전.)
-  //  3) meta 도 실패·pdfId 도 없으면 레거시 per-page API 로 마지막 폴백.
-  useEffect(() => {
-    if (sourceFile) return;
-    if (!roomData?.roomId || !roomData?.deckId) return;
-    if (restoredSlides !== null) return;
-
-    const pages = roomData.totalPages || 0;
-    if (pages <= 0) return;
-
-    const pdfIdFromStorage: string | undefined = roomData.pdfId;
-
-    const resubscribeSse = () => {
-      if (!pdfIdFromStorage) return false;
-      setTotalPages(pages);
-      setStreamUrl(`/api/pdf/${pdfIdFromStorage}/stream`);
-      hasInitializedRef.current = true;
-      return true;
-    };
-
-    const restore = async () => {
-      try {
-        const urls = await fetchSlidesMeta(roomData.roomId, roomData.deckId, pages);
-        const allReady = urls.length === pages && urls.every((u) => !!u);
-        if (allReady) {
-          setRestoredSlides(urls);
-          setTotalPages(pages);
-          setRoomData((prev: any) => ({ ...prev, canStartSession: true }));
-          hasInitializedRef.current = true;
-          return;
-        }
-        // meta 가 부분만 반환 → BE 가 아직 렌더링 중. SSE 로 재구독해 남은 페이지 수신.
-        if (resubscribeSse()) {
-          log.warn("meta 부분 응답, SSE 재구독으로 전환");
-          return;
-        }
-        throw new Error("meta 응답이 비어 있음");
-      } catch (metaErr) {
-        log.warn("meta 조회 실패:", metaErr);
-        if (resubscribeSse()) return;
-        // 최후 폴백: 레거시 per-page API
-        try {
-          const urls = await fetchAllOriginalSlideUrls(roomData.roomId, roomData.deckId, pages);
-          setRestoredSlides(urls);
-          setTotalPages(pages);
-          setRoomData((prev: any) => ({ ...prev, canStartSession: true }));
-          hasInitializedRef.current = true;
-        } catch (err) {
-          log.error("슬라이드 복원 실패:", err);
-        }
-      }
-    };
-
-    restore();
-  }, [
-    sourceFile,
-    roomData?.roomId,
-    roomData?.deckId,
-    roomData?.totalPages,
-    roomData?.pdfId,
-    restoredSlides,
-  ]);
-
-  const applyReady = useCallback(
-    (room: any, ready: ChunkUploadReady) => {
-      const nextRoomData = {
-        ...room,
-        deckId: room.deckId,
-        totalPages: ready.totalPages,
-        pdfId: ready.pdfId,
-        fileName: ready.fileName,
-        canStartSession: false,
-        pdfDownloadEnabled: false,
-      };
-      setRoomData(nextRoomData);
-      setTotalPages(ready.totalPages);
-      setStreamUrl(ready.streamUrl);
-      sessionStorage.setItem("boini_room", JSON.stringify(nextRoomData));
-      setPendingFonts(null);
-
-      if (roomIdParam !== room.roomId) {
-        navigate(`/rooms/${room.roomId}`, {
-          replace: true,
-          state: {
-            ...(location.state || {}),
-            roomData: nextRoomData,
-            roomId: room.roomId,
-            deckId: room.deckId,
-            totalPages: ready.totalPages,
-          },
-        });
-      }
-    },
-    [navigate, roomIdParam, location.state]
-  );
-
-  // 폰트 업로드 / 변환 시작은 React Query mutation 으로 처리한다(청크 업로드는 raw axios 유지).
-  const { uploadFont, finalize: runFinalize, uploadingName, busy: fontBusy } = useFontMutations({
-    onUploaded: (fontName, res) => {
-      setFontError(null);
-      // 서버는 전체 리포트를 재분석하지 않으므로, 일치하면 해당 폰트만 로컬에서 '사용 가능'으로 바꾼다.
-      if (res.matched) {
-        setPendingFonts((prev) =>
-          prev
-            ? {
-                ...prev,
-                fontReport: prev.fontReport.map((e) =>
-                  e.name === fontName ? { ...e, status: "AVAILABLE" as const, installed: true } : e
-                ),
-              }
-            : prev
-        );
-        setFontWarnings((prev) => {
-          const next = { ...prev };
-          delete next[fontName];
-          return next;
-        });
-      } else {
-        setFontWarnings((prev) => ({ ...prev, [fontName]: res.uploadedFamilies?.[0] ?? "" }));
-      }
-    },
-    onUploadError: () => setFontError("폰트 업로드에 실패했습니다. 다시 시도해주세요."),
-    onFinalized: (ready) => applyReady(pendingRoomRef.current, ready),
-    onFinalizeError: () => setFontError("변환을 시작하지 못했습니다. 다시 시도해주세요."),
-  });
-
-  const handleUploadFont = useCallback(
-    (fontName: string, file: File) => {
-      if (!pendingFonts) return;
-      setFontError(null);
-      uploadFont(pendingFonts.uploadId, fontName, file);
-    },
-    [pendingFonts, uploadFont]
-  );
-
-  const handleContinue = useCallback(() => {
-    if (!pendingFonts) return;
-    setFontError(null);
-    runFinalize(pendingFonts.uploadId, false);
-  }, [pendingFonts, runFinalize]);
-
-  const handleProceedWithout = useCallback(() => {
-    if (!pendingFonts) return;
-    setFontError(null);
-    runFinalize(pendingFonts.uploadId, true);
-  }, [pendingFonts, runFinalize]);
-
-  // 신규 업로드 플로우: createRoom → 청크 업로드 → SSE 스트림 구독
-  useEffect(() => {
-    if (hasInitializedRef.current) return;
-    // sourceFile 이 없는 경우(= 새로고침 복원)만 기존 roomData 로 skip. sourceFile 이 있으면
-    // stale roomData 가 있더라도 신규 업로드가 우선.
-    if (!sourceFile && roomData?.roomId) {
-      hasInitializedRef.current = true;
-      return;
-    }
-    if (!sourceFile) {
-      navigate("/");
-      return;
-    }
-
-    hasInitializedRef.current = true;
-
-    // 신규 업로드 진입 — 이전 세션 잔재(atom, sessionStorage, 로컬 state)를 모두 리셋.
-    setCanStartSessionAtomValue(false);
-    try {
-      sessionStorage.removeItem("boini_room");
-    } catch {
-      /* ignore */
-    }
-    setTotalPages(0);
-    setStreamUrl(null);
-    setRoomData(null);
-
-    const run = async () => {
-      try {
-        // BE 는 totalPages >= 1 을 요구하므로 placeholder 로 1 을 보낸다.
-        // 실제 총 페이지는 업로드 조립 완료 응답(ready.totalPages) 에서 확정된다.
-        const room = await createRoom(1);
-        pendingRoomRef.current = room;
-        const terminal = await uploadPdf(sourceFile, room.roomId, room.deckId);
-        if (terminal.status === "NEEDS_FONTS") {
-          setPendingFonts({ uploadId: terminal.uploadId, fontReport: terminal.fontReport });
-          return; // Phase B는 사용자 액션(폰트 업로드/그냥 진행)으로 트리거됨
-        }
-        applyReady(room, terminal);
-      } catch (err) {
-        log.error("발표 자료 업로드/스트림 준비 실패:", err);
-        hasInitializedRef.current = false;
-        setFatalMessage("발표 자료 업로드에 실패했습니다. 다시 시도해주세요.");
-      }
-    };
-
-    run();
-  }, [
-    sourceFile,
-    roomData?.roomId,
-    roomIdParam,
-    navigate,
-    location.state,
-    uploadPdf,
-    setCanStartSessionAtomValue,
-    applyReady,
-  ]);
-
   // canStartSession 이 true 가 되면 atom + roomData + sessionStorage 를 모두 동기화.
   // AppHeader 는 atom 을 구독해 즉시 재렌더되고, 새로고침 대비로 sessionStorage 에도 저장한다.
   // 새로고침 복원 경로는 restoredSlides 채워지는 시점에 canStartSession 을 true 로 간주.
@@ -470,14 +361,10 @@ const PresentationPrepPage = () => {
     const effective = canStartSession || !!restoredSlides;
     if (!effective) return;
     setCanStartSessionAtomValue(true);
-    setRoomData((prev: any) => {
+    setRoomData((prev) => {
       if (!prev || prev.canStartSession === true) return prev;
       const next = { ...prev, canStartSession: true };
-      try {
-        sessionStorage.setItem("boini_room", JSON.stringify(next));
-      } catch {
-        /* ignore */
-      }
+      persistRoomData(next);
       return next;
     });
   }, [canStartSession, restoredSlides, setCanStartSessionAtomValue]);
@@ -561,25 +448,51 @@ const PresentationPrepPage = () => {
     };
   }, [displaySlides.length]);
 
-  if (fatalMessage) {
-    return <SessionLoadingOverlay message={`⚠️ ${fatalMessage}`} />;
+  // ── 상태별 화면 분기 ──
+  if (phase.step === "failed") {
+    return <UploadErrorPanel message={phase.message} onRetry={retryUpload} onGoHome={goHome} />;
   }
 
-  if (pendingFonts) {
+  if (fatalMessage) {
+    // SSE 치명 오류(PDF_LOAD_FAILED 등) — 원본 File 이 이미 해제됐을 수 있어 처음부터 다시.
+    return <UploadErrorPanel message={fatalMessage} onGoHome={goHome} />;
+  }
+
+  if (restoreOutcome?.kind === "failed") {
+    return (
+      <UploadErrorPanel
+        message="발표 자료를 불러오지 못했습니다."
+        onRetry={retryRestore}
+        onGoHome={goHome}
+      />
+    );
+  }
+
+  if (uploadInterrupted) {
+    return (
+      <UploadErrorPanel
+        message="업로드가 완료되지 않았습니다. 발표 자료를 다시 선택해주세요."
+        onGoHome={goHome}
+        homeLabel="파일 다시 선택"
+      />
+    );
+  }
+
+  if (phase.step === "awaiting-fonts") {
     return (
       <>
         <SessionLoadingOverlay message="발표 자료 준비 중..." />
         {/* 변환(finalize) 시작하면 모달을 닫아, 사용자가 '준비 중' 로딩 화면을 보게 한다. */}
-        {!fontBusy && (
+        {!fonts.busy && (
           <FontRequirementPrompt
-            fontReport={pendingFonts.fontReport}
-            busy={fontBusy}
-            uploadingName={uploadingName}
-            warnings={fontWarnings}
-            error={fontError}
-            onUploadFont={handleUploadFont}
-            onContinue={handleContinue}
-            onProceedWithout={handleProceedWithout}
+            fontReport={phase.fontReport}
+            busy={fonts.busy}
+            uploadingName={fonts.uploadingName}
+            warnings={fonts.warnings}
+            error={fonts.error}
+            onUploadFont={fonts.uploadFont}
+            onContinue={fonts.continueWithFonts}
+            onProceedWithout={fonts.proceedWithoutFonts}
           />
         )}
       </>
@@ -590,15 +503,19 @@ const PresentationPrepPage = () => {
   // 업로드 완료로 totalPages 가 확정되거나 새로고침 복원이 끝나면 곧바로 대시보드를 열고,
   // 각 슬라이드는 SSE 로 도착하는 대로 비동기로 채워진다.
   if (totalPages === 0 && !restoredSlides) {
-    const msg =
-      uploadProgress.total > 0
-        ? `발표 자료 업로드 중... (${uploadProgress.sent}/${uploadProgress.total})`
-        : "세션 자료 준비 중...";
-    return <SessionLoadingOverlay message={msg} />;
+    if (isUploadOverlayActive) {
+      return (
+        <SessionLoadingOverlay message={uploadMessage}>
+          <UploadCancelButton type="button" onClick={goHome}>
+            업로드 취소
+          </UploadCancelButton>
+        </SessionLoadingOverlay>
+      );
+    }
+    return <SessionLoadingOverlay message="세션 자료 준비 중..." />;
   }
 
-  void streamDone;
-  void totalPages;
+  const renderFailureCount = Object.keys(pageErrors).length;
 
   return (
     <PresentationLayout>
@@ -655,6 +572,12 @@ const PresentationPrepPage = () => {
           </>
         }
       />
+      {renderFailureCount > 0 && !renderFailureDismissed && (
+        <RenderFailureBanner
+          failedCount={renderFailureCount}
+          onDismiss={() => setRenderFailureDismissed(true)}
+        />
+      )}
     </PresentationLayout>
   );
 };

--- a/src/pages/session-create/ui/UploadErrorPanel.styles.ts
+++ b/src/pages/session-create/ui/UploadErrorPanel.styles.ts
@@ -1,0 +1,71 @@
+import styled from "styled-components";
+
+export const Overlay = styled.div`
+  position: fixed;
+  inset: 0;
+  min-height: 100dvh;
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(15px);
+  -webkit-backdrop-filter: blur(15px);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 24px;
+  z-index: 9999;
+  padding: 0 24px;
+`;
+
+export const Icon = styled.div`
+  font-size: 48px;
+  line-height: 1;
+`;
+
+export const Message = styled.p`
+  margin: 0;
+  color: #303030;
+  font-size: 24px;
+  font-weight: 600;
+  line-height: 34px;
+  text-align: center;
+  word-break: keep-all;
+  max-width: 560px;
+`;
+
+export const Actions = styled.div`
+  display: flex;
+  gap: 12px;
+`;
+
+export const RetryButton = styled.button`
+  padding: 12px 28px;
+  border: none;
+  border-radius: 8px;
+  background: #e8541e;
+  color: #fff;
+  font-size: 16px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: 0.2s;
+
+  &:hover {
+    background: #cc3f13;
+  }
+`;
+
+export const HomeButton = styled.button`
+  padding: 12px 28px;
+  border: 1px solid #d9d9d9;
+  border-radius: 8px;
+  background: transparent;
+  color: #5c5c5c;
+  font-size: 16px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: 0.2s;
+
+  &:hover {
+    border-color: #b0b0b0;
+    color: #303030;
+  }
+`;

--- a/src/pages/session-create/ui/UploadErrorPanel.tsx
+++ b/src/pages/session-create/ui/UploadErrorPanel.tsx
@@ -1,0 +1,40 @@
+import {
+  Actions,
+  HomeButton,
+  Icon,
+  Message,
+  Overlay,
+  RetryButton,
+} from "./UploadErrorPanel.styles";
+
+interface UploadErrorPanelProps {
+  message: string;
+  /** 없으면 재시도 버튼을 숨긴다 (예: 원본 파일이 이미 유실된 경우) */
+  onRetry?: () => void;
+  onGoHome: () => void;
+  homeLabel?: string;
+}
+
+const UploadErrorPanel = ({
+  message,
+  onRetry,
+  onGoHome,
+  homeLabel = "처음으로",
+}: UploadErrorPanelProps) => (
+  <Overlay role="alert">
+    <Icon aria-hidden="true">⚠️</Icon>
+    <Message>{message}</Message>
+    <Actions>
+      {onRetry && (
+        <RetryButton type="button" onClick={onRetry}>
+          다시 시도
+        </RetryButton>
+      )}
+      <HomeButton type="button" onClick={onGoHome}>
+        {homeLabel}
+      </HomeButton>
+    </Actions>
+  </Overlay>
+);
+
+export default UploadErrorPanel;

--- a/src/shared/api/room.ts
+++ b/src/shared/api/room.ts
@@ -5,11 +5,11 @@ import { DEFAULT_AUDIENCE_CAPACITY } from "@/shared/config/audience";
 
 const log = createLogger("room");
 
-export async function createRoom(totalPages = 10): Promise<RoomData> {
+export async function createRoom(totalPages = 10, signal?: AbortSignal): Promise<RoomData> {
   const requestData = { count: DEFAULT_AUDIENCE_CAPACITY, totalPages };
   log.log("Creating room", requestData);
 
-  const res = await api.post("/api/rooms", requestData);
+  const res = await api.post("/api/rooms", requestData, { signal });
   return res.data.data;
 }
 

--- a/src/shared/api/uploadError.ts
+++ b/src/shared/api/uploadError.ts
@@ -1,0 +1,28 @@
+import { isAxiosError } from "axios";
+
+// 백엔드 PdfErrorCode → 사용자 안내 문구.
+// 행동 지침이 필요한 코드만 덮어쓰고, 나머지는 서버 메시지 → fallback 순으로 사용한다.
+const UPLOAD_ERROR_MESSAGES: Record<string, string> = {
+  P012: "지원하지 않는 파일 형식입니다. PDF, PPT, PPTX 파일만 업로드할 수 있어요.",
+  P023: "PPT 파일을 변환하지 못했습니다. PDF로 저장한 뒤 다시 업로드해보세요.",
+  P031: "폰트 파일이 유효하지 않습니다. TTF/OTF 파일인지 확인해주세요.",
+  P032: "폰트 파일이 너무 큽니다.",
+  P033: "업로드할 수 있는 폰트 개수를 초과했습니다.",
+  P034: "업로드한 폰트의 총 용량이 허용치를 초과했습니다.",
+  P036: "업로드 세션이 만료되었습니다. 처음부터 다시 시도해주세요.",
+};
+
+/** axios 에러에서 BaseResponse 의 code/message 를 꺼내 사용자 문구로 변환한다. */
+export function getUploadErrorMessage(err: unknown, fallback: string): string {
+  if (isAxiosError(err)) {
+    if (!err.response) {
+      return "네트워크 연결이 불안정합니다. 연결을 확인한 뒤 다시 시도해주세요.";
+    }
+    const data = err.response.data as { code?: string; message?: string } | undefined;
+    if (data?.code && UPLOAD_ERROR_MESSAGES[data.code]) {
+      return UPLOAD_ERROR_MESSAGES[data.code];
+    }
+    if (data?.message) return data.message;
+  }
+  return fallback;
+}

--- a/src/shared/config/upload.ts
+++ b/src/shared/config/upload.ts
@@ -1,0 +1,5 @@
+// 발표 자료 업로드 최대 크기. 백엔드는 청크(2MB) 단위 제한만 있고 전체 파일 크기 제한이
+// 없으므로 프론트에서 선제적으로 차단한다.
+export const MAX_PRESENTATION_FILE_BYTES = 200 * 1024 * 1024;
+
+export const MAX_PRESENTATION_FILE_LABEL = "200MB";

--- a/src/shared/ui/session-loading-overlay/SessionLoadingOverlay.tsx
+++ b/src/shared/ui/session-loading-overlay/SessionLoadingOverlay.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import {
   BrandMark,
   Center,
@@ -9,9 +10,14 @@ import {
 
 interface SessionLoadingOverlayProps {
   message?: string;
+  /** 메시지 아래에 렌더링되는 부가 콘텐츠 슬롯 (진행률, 액션 버튼 등) */
+  children?: ReactNode;
 }
 
-const SessionLoadingOverlay = ({ message = "세션 자료 정리 중..." }: SessionLoadingOverlayProps) => {
+const SessionLoadingOverlay = ({
+  message = "세션 자료 정리 중...",
+  children,
+}: SessionLoadingOverlayProps) => {
   return (
     <Overlay role="status" aria-live="polite">
       <Center aria-hidden="true">
@@ -28,6 +34,7 @@ const SessionLoadingOverlay = ({ message = "세션 자료 정리 중..." }: Sess
         </MarkSurface>
       </Center>
       <Message>{message}</Message>
+      {children}
     </Overlay>
   );
 };

--- a/src/widgets/app-header/model/room/useHeaderRoomData.ts
+++ b/src/widgets/app-header/model/room/useHeaderRoomData.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { useLocation } from "react-router";
+import { STORAGE_KEYS } from "@/shared/config/storage-keys";
 
 /**
  * * Resolves roomData from props or sessionStorage.
@@ -17,7 +18,7 @@ export const useHeaderRoomData = (propRoomData: any) => {
     let storedRoomData: Record<string, unknown> | null = null;
 
     try {
-      const stored = sessionStorage.getItem("boini_room");
+      const stored = sessionStorage.getItem(STORAGE_KEYS.ROOM);
       storedRoomData = stored ? JSON.parse(stored) : null;
     } catch {
       storedRoomData = null;


### PR DESCRIPTION
## 요약

세션 생성(업로드) 플로우를 다시 짰습니다. 직렬화가 안 되는 `File`을 `location.state`로 넘기던 구조를 아톰으로 바꾸고, `createRoom` → 청크 업로드 → 폰트 → SSE로 이어지는 과정을 하나의 페이즈 머신 훅으로 모았습니다. **업로드 도중 새로고침해도 랜딩으로 튕기지 않고 복구 화면이 뜹니다.**

## ✅ 주요 작업 내용

### 파일 전달 · 플로우 오케스트레이션

- 선택한 `File`을 `pendingPresentationFileAtom`으로 전달 — 랜딩은 `{ fileName }`만 넘깁니다
- `usePresentationUploadFlow`가 방 생성 → 청크 업로드 → 폰트 → SSE 전 구간을 reducer 페이즈로 관리합니다. 언마운트 시 abort하고, 재시도는 **이미 만든 방을 재사용**하면서 `uploadId`만 새로 발급합니다

### 새로고침 복구

- 방 생성 직후 곧바로 `/rooms/:roomId`로 이동하고 `totalPages: 0` 스켈레톤을 저장합니다. 업로드 중 새로고침해도 조용히 랜딩으로 되돌아가지 않고 복구 패널이 뜹니다
- 복구 경로를 `useRestorePresenterSlides`로 분리했습니다 (meta → SSE 재구독 → 레거시 폴백). 실패하면 재시도 가능한 패널을 보여줍니다

### 에러 · 취소 UX

- 업로드 취소, 재시도 가능한 에러 패널(`UploadErrorPanel`), 페이지별 렌더 실패 배너(`RenderFailureBanner`)
- `PdfErrorCode` → 사용자 문구 매핑을 `shared/api/uploadError.ts`로 분리
- 랜딩 인라인 검증 — 형식/용량 사유를 구분하고 200MB 상한, 키보드 접근성 추가

### 그 외

- 진행률 바 대신 시간에 따라 문구가 바뀌는 방식(`useRollingMessage`)으로 교체했습니다. 청크 프로토콜에 정직한 진행률 신호가 없어서입니다 — 마지막 응답이 서버 변환이 끝날 때까지 블로킹됩니다
- 하드코딩된 `"boini_room"` 리터럴을 `STORAGE_KEYS.ROOM` + `persistRoomData`/`readPersistedRoomData` 헬퍼로 대체했습니다

## 🔍 확인

- `pnpm typecheck` 통과
- `pnpm lint` **에러 0** (경고 173건은 모두 기존 `any` 경고)
- `pnpm build` 성공
- `pnpm test:unit` — 42 passed / 6 failed. 실패 6건(`resolveRatingSessionContext` 2, `feedback-answers-api` 1, `FontRequirementPrompt` 3)은 **`dev`에서도 동일하게 실패**하는 기존 실패라 이 브랜치와 무관합니다

## 📌 리뷰 포인트

- 청크 업로드에는 **청크 단위 재시도가 없습니다**(백엔드가 INCR 기반이라 부분 재전송이 안전하지 않음) — 전체 재시도만 제공합니다
- pdf.js 미리보기는 이번 범위에서 제외했습니다
