### PR TITLE
배포: dev → main (2026-07-24)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@stomp/stompjs": "^7.2.1",
     "@tanstack/react-query": "^5.101.2",
     "axios": "^1.12.2",
+    "driver.js": "^1.8.0",
     "jotai": "^2.19.0",
     "posthog-js": "^1.399.2",
     "qrcode.react": "^4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       axios:
         specifier: ^1.12.2
         version: 1.13.6
+      driver.js:
+        specifier: ^1.8.0
+        version: 1.8.0
       jotai:
         specifier: ^2.19.0
         version: 2.19.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.4)
@@ -1412,6 +1415,9 @@ packages:
 
   dompurify@3.4.12:
     resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+
+  driver.js@1.8.0:
+    resolution: {integrity: sha512-+8/IO7h1v14IzWh2GP60N7T3PFZweXwdn5e5POuxRSBoCYUojsBxzqawPeXh3YZIibRy7EehYNEyxe7slwwtdg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -3946,6 +3952,8 @@ snapshots:
   dompurify@3.4.12:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
+
+  driver.js@1.8.0: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/src/pages/ai-report/model/tour/reportTourSteps.ts
+++ b/src/pages/ai-report/model/tour/reportTourSteps.ts
@@ -1,0 +1,48 @@
+import type { TourStepContent } from "@/shared/lib/tour";
+
+export const reportTourSteps: TourStepContent[] = [
+  {
+    target: '[data-tour="report-totalReaction"]',
+    title: "전체 반응 요약",
+    body: "이번 세션에서 청중이 남긴 반응의 수를 한눈에 요약했어요.",
+  },
+  {
+    target: '[data-tour="report-top3"]',
+    title: "전체 질문 요약",
+    body: "이번 세션에서 받은 질문들을 정리했어요.",
+  },
+  {
+    target: '[data-tour="report-popularSlide"]',
+    title: "인기 슬라이드",
+    body: "스티커별로 반응이 가장 많았던 슬라이드를 나열했어요.",
+  },
+  {
+    target: '[data-tour="report-questionSlide"]',
+    title: "최다 질문 슬라이드",
+    body: "가장 질문을 많이 받은 슬라이드를 뽑았어요.",
+  },
+  {
+    target: '[data-tour="report-replaySlide"]',
+    title: "여러 번 다시 본 슬라이드",
+    body: "청중이 가장 많이 되돌아본 슬라이드예요.\n가장 흥미로웠거나 이해하기 어려웠던 지점일 수 있어요.",
+  },
+  {
+    target: '[data-tour="report-review"]',
+    title: "청중 후기",
+    body: "이번 세션에 대한 만족도와 후기를 정리했어요.\n후기가 쌓이면 목록이 자동으로 새로고침돼요.",
+  },
+  {
+    target: '[data-tour="csv-download-button"]',
+    title: "CSV 다운로드",
+    body: "청중이 남긴 후기를 CSV 파일로 다운로드받을 수도 있어요.",
+    side: "bottom",
+    align: "end",
+  },
+  {
+    target: '[data-tour="exit-button"]',
+    title: "나가기",
+    body: "리포트 확인을 마쳤다면 여기를 눌러 나갈 수 있어요.\n수고하셨어요!",
+    side: "bottom",
+    align: "end",
+  },
+];

--- a/src/pages/ai-report/ui/AiReportPage.tsx
+++ b/src/pages/ai-report/ui/AiReportPage.tsx
@@ -3,6 +3,8 @@ import { useLocation, useParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { usePostHog } from "@posthog/react";
 import { ANALYTICS_EVENTS, ANALYTICS_GROUP_SESSION } from "@/shared/config/analytics-events";
+import { useTour } from "@/shared/lib/tour";
+import { reportTourSteps } from "../model/tour/reportTourSteps";
 import { PageContainer, ContentContainer, FooterContainer } from "./AiReportPage.styles";
 import { SideHeader } from "./navigation";
 import {
@@ -143,11 +145,15 @@ const AiReportPage = () => {
     };
   }, [storedReport, revisitReport]);
 
+  // 온보딩 투어(AI 리포트) — 리포트 데이터가 실제로 로드된 뒤 첫 방문 시 자동 실행.
+  const reportReady = !reportLoading && !reportError && !!storedReport;
+  useTour({ surface: "report", steps: reportTourSteps, enabled: reportReady, roomId });
+
   return (
     <PageContainer>
       <SideHeader onIconClick={scrollToSection} activeSection={activeSection} />
       <ContentContainer ref={contentContainerRef}>
-        <div ref={totalReactionRef}>
+        <div ref={totalReactionRef} data-tour="report-totalReaction">
           <TotalReaction
             reportData={storedReport}
             loading={reportLoading}
@@ -157,16 +163,16 @@ const AiReportPage = () => {
             fileName={fileName}
           />
         </div>
-        <div ref={top3Ref}>
+        <div ref={top3Ref} data-tour="report-top3">
           <Top3 />
         </div>
-        <div ref={popularSlideRef}>
+        <div ref={popularSlideRef} data-tour="report-popularSlide">
           <PopularSlide roomId={roomId} deckId={deckId} />
         </div>
-        <div ref={questionSlideRef}>
+        <div ref={questionSlideRef} data-tour="report-questionSlide">
           <QuestionSlide />
         </div>
-        <div ref={replaySlideRef}>
+        <div ref={replaySlideRef} data-tour="report-replaySlide">
           <ReplaySlide
             reportData={revisitReport}
             loading={revisitLoading}
@@ -175,7 +181,7 @@ const AiReportPage = () => {
             deckId={deckId}
           />
         </div>
-        <div ref={reviewRef}>
+        <div ref={reviewRef} data-tour="report-review">
           <ReviewSlide />
         </div>
         <FooterContainer>

--- a/src/pages/presenter-room/model/tour/presentTourSteps.ts
+++ b/src/pages/presenter-room/model/tour/presentTourSteps.ts
@@ -1,0 +1,23 @@
+import type { TourStepContent } from "@/shared/lib/tour";
+
+export const presentTourSteps: TourStepContent[] = [
+  {
+    target: '[data-tour="slide-surface"]',
+    title: "발표 화면",
+    body: "청중이 보는 현재 슬라이드예요.\n방향키로 넘기고, 우측 상단 타이머로 시간을 확인하세요.",
+    side: "bottom",
+  },
+  {
+    target: '[data-tour="present-settings"]',
+    title: "세션 설정",
+    body: "모든 설정은 발표 중에도 언제든 켜고 끌 수 있어요.",
+    side: "left",
+  },
+  {
+    target: '[data-tour="start-session-button"]',
+    title: "세션 종료",
+    body: "발표를 마치면 이 버튼을 눌러 세션을 종료하세요. ",
+    side: "bottom",
+    align: "end",
+  },
+];

--- a/src/pages/presenter-room/ui/PresenterRoomPage.tsx
+++ b/src/pages/presenter-room/ui/PresenterRoomPage.tsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect, useMemo, useCallback, useRef } from "react"
 import type { ChangeEvent } from "react";
 import { useLocation, useParams } from "react-router";
 import { usePostHog } from "@posthog/react";
+import { useTour } from "@/shared/lib/tour";
+import { presentTourSteps } from "../model/tour/presentTourSteps";
 import { ANALYTICS_EVENTS, ANALYTICS_GROUP_SESSION } from "@/shared/config/analytics-events";
 import { STORAGE_KEYS } from "@/shared/config/storage-keys";
 import {
@@ -489,6 +491,15 @@ const PresenterRoomPage = () => {
     [changeSlide]
   );
 
+  // 온보딩 투어(발표 화면) — 조용한 프리셋. 슬라이드 로드 후 첫 방문 시 자동 실행.
+  useTour({
+    surface: "present",
+    steps: presentTourSteps,
+    preset: "quiet",
+    enabled: !loading && slideUrls.length > 0,
+    roomId,
+  });
+
   // ✅ 로딩 중일 때 표시
   if (loading) {
     return (
@@ -586,7 +597,7 @@ const PresenterRoomPage = () => {
         <NextSlidePreview slides={slideUrls} currentSlide={currentSlide} />
 
         {/* === 세션 설정 섹션 === */}
-        <CollapsibleSection title="세션 설정">
+        <CollapsibleSection title="세션 설정" dataTour="present-settings" expandableForTour>
           <QuickTogglesList>
             <QuickSettingToggle
               label="실시간 질문"

--- a/src/pages/session-create/model/tour/prepareTourSteps.ts
+++ b/src/pages/session-create/model/tour/prepareTourSteps.ts
@@ -1,0 +1,85 @@
+import type { TourStepContent } from "@/shared/lib/tour";
+
+export const prepareTourSteps: TourStepContent[] = [
+  {
+    title: "보이니에 오신 걸 환영해요 👋",
+    body: "먼저 세션 준비부터 안내해 드릴게요.\n1분이면 끝나요!",
+  },
+  {
+    target: '[data-tour="slide-surface"]',
+    title: "슬라이드 미리보기",
+    body: "업로드한 슬라이드예요.\n방향키(←→↑↓)로 넘기며 순서와 내용을 확인하세요.",
+    side: "bottom",
+  },
+  {
+    target: '[data-tour="focus-button"]',
+    title: "집중 유도",
+    body: "세션 도중에 이 버튼을 누르면 모든 청중을 현재 슬라이드로 불러요.\n이전 슬라이드를 보고 있는 청중들의 시선을 다시 모을 때 유용해요.",
+    side: "bottom",
+    align: "start",
+  },
+  {
+    target: '[data-tour="sticker-visibility"]',
+    title: "리액션 스티커 표시",
+    body: "내 발표 화면에서 청중의 리액션 스티커를 보이거나 숨겨요.\n발표에 집중하고 싶을 땐 꺼두세요.",
+    side: "bottom",
+    align: "end",
+  },
+  {
+    target: '[data-tour="setting-question"]',
+    title: "실시간 질문",
+    body: "켜면 청중이 세션 도중에 질문을 남길 수 있어요. 끄면 질문창이 잠겨요.",
+    side: "left",
+  },
+  {
+    target: '[data-tour="setting-sticker"]',
+    title: "리액션 스티커",
+    body: "켜면 청중이 슬라이드에 리액션 스티커로 반응할 수 있어요.",
+    side: "left",
+  },
+  {
+    target: '[data-tour="setting-unlock"]',
+    title: "다음 구간 슬라이드 공개",
+    body: "켜면 청중이 다음 구간 슬라이드를 미리 볼 수 있어요.\n스포일러 방지를 위해선 꺼두세요.",
+    side: "left",
+  },
+  {
+    target: '[data-tour="setting-pdf"]',
+    title: "PDF 다운로드 허용",
+    body: "세션 종료 후 후기를 작성한 청중에게만 발표 자료를 PDF로 다운로드할 수 있게 할 수 있어요.",
+    side: "left",
+  },
+  {
+    target: '[data-tour="setting-broadcast"]',
+    title: "깔끔한 발표 화면 열기",
+    body: "외부 디스플레이(빔프로젝터, 보조 모니터 등)에 슬라이드만 띄우는 발표 화면을 열 수 있어요.",
+    side: "left",
+  },
+  {
+    target: '[data-tour="live-question-panel"]',
+    title: "실시간 질문",
+    body: "세션이 시작되면 청중 질문이 여기에 실시간으로 쌓여요.\n답변한 질문은 완료 처리할 수 있어요.",
+    side: "left",
+  },
+  {
+    target: '[data-tour="feedback-form-button"]',
+    title: "세션 후기 질문 작성",
+    body: "발표를 마친 후 청중에게 물어볼 후기 질문을 미리 만들어 두세요.\n세션이 끝난 후 AI 리포트에서 볼 수 있어요.",
+    side: "bottom",
+    align: "end",
+  },
+  {
+    target: '[data-tour="share-button"]',
+    title: "청중 초대",
+    body: "세션 링크를 복사해 청중을 초대하세요.",
+    side: "bottom",
+    align: "end",
+  },
+  {
+    target: '[data-tour="start-session-button"]',
+    title: "이제 시작해 볼까요?",
+    body: "준비가 끝나면 '세션 시작'을 눌러 발표를 시작하세요!",
+    side: "bottom",
+    align: "end",
+  },
+];

--- a/src/pages/session-create/ui/SessionCreatePage.tsx
+++ b/src/pages/session-create/ui/SessionCreatePage.tsx
@@ -25,12 +25,14 @@ import { storageKeys } from "@/shared/config/storage-keys";
 import { DEFAULT_AUDIENCE_CAPACITY } from "@/shared/config/audience";
 import websocketService from "@/shared/api/websocket";
 import { useBroadcastPublisher, useBroadcastReactionVisibility } from "@/shared/lib/broadcast";
+import { useTour } from "@/shared/lib/tour";
 import type { ChunkUploadReady } from "@/shared/api/model/pdf";
 import { usePresentationUploadFlow } from "../model/usePresentationUploadFlow";
 import { usePdfStream } from "../model/usePdfStream";
 import { useRestorePresenterSlides } from "../model/useRestorePresenterSlides";
 import { useRollingMessage } from "../model/useRollingMessage";
 import { resolvePresenterRoomData } from "../model/resolvePresenterRoomData";
+import { prepareTourSteps } from "../model/tour/prepareTourSteps";
 import FontRequirementPrompt from "./FontRequirementPrompt";
 import UploadErrorPanel from "./UploadErrorPanel";
 import RenderFailureBanner from "./RenderFailureBanner";
@@ -447,6 +449,10 @@ const PresentationPrepPage = () => {
       window.removeEventListener("keydown", handleKeyDown);
     };
   }, [displaySlides.length]);
+
+  // 온보딩 투어(준비 화면) — 슬라이드가 실제로 한 장이라도 렌더된 뒤 첫 방문 시 자동 실행.
+  const slidesReady = displaySlides.length > 0 && displaySlides.some(Boolean);
+  useTour({ surface: "prepare", steps: prepareTourSteps, enabled: slidesReady, roomId });
 
   // ── 상태별 화면 분기 ──
   if (phase.step === "failed") {

--- a/src/shared/assets/images/help.svg
+++ b/src/shared/assets/images/help.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="9" stroke="#5c5c5c" stroke-width="1.8"/>
+  <path d="M9.5 9.2c0-1.4 1.1-2.4 2.6-2.4 1.4 0 2.5.9 2.5 2.2 0 1.1-.7 1.7-1.6 2.2-.8.5-1.1.9-1.1 1.7v.3" stroke="#5c5c5c" stroke-width="1.8" stroke-linecap="round"/>
+  <circle cx="12" cy="16.8" r="1" fill="#5c5c5c"/>
+</svg>

--- a/src/shared/config/analytics-events.ts
+++ b/src/shared/config/analytics-events.ts
@@ -21,6 +21,12 @@ export const ANALYTICS_EVENTS = {
   BROADCAST_SCREEN_OPENED: "broadcast_screen_opened",
   AI_REPORT_VIEWED: "ai_report_viewed",
 
+  // Onboarding tour
+  ONBOARDING_TOUR_STARTED: "onboarding_tour_started",
+  ONBOARDING_TOUR_STEP_VIEWED: "onboarding_tour_step_viewed",
+  ONBOARDING_TOUR_COMPLETED: "onboarding_tour_completed",
+  ONBOARDING_TOUR_SKIPPED: "onboarding_tour_skipped",
+
   // Audience funnel
   LANDING_JOIN_CODE_SUBMITTED: "landing_join_code_submitted",
   AUDIENCE_SESSION_JOINED: "audience_session_joined",

--- a/src/shared/config/storage-keys.ts
+++ b/src/shared/config/storage-keys.ts
@@ -18,6 +18,8 @@ export const storageKeys = {
   broadcastReactionsVisible: (roomId: string) => `boini_broadcast_reactions_${roomId}` as const,
   // 발표자가 이 브라우저에서 세션을 시작했음을 기록하는 마커 (새로고침 시 발표 화면 복원에 사용)
   sessionStarted: (roomId: string) => `boini_session_started_${roomId}` as const,
+  // 온보딩 투어를 이 브라우저에서 이미 봤는지 표시 (localStorage, 세션 간 유지)
+  tourSeen: (surface: string) => `boini_tour_seen_${surface}` as const,
 } as const;
 
 /** 발표 세션 시작 마커 헬퍼 — 백엔드 상태 조회가 실패해도 발표자 본인의 새로고침을 복원. */

--- a/src/shared/lib/tour/driver-config.ts
+++ b/src/shared/lib/tour/driver-config.ts
@@ -1,0 +1,74 @@
+import { driver } from "driver.js";
+import type { Config, Driver, DriveStep } from "driver.js";
+import "driver.js/dist/driver.css";
+import type { TourPreset, TourStepContent } from "./types";
+
+const BASE_CONFIG: Config = {
+  showProgress: true,
+  progressText: "{{current}} / {{total}}",
+  nextBtnText: "다음",
+  prevBtnText: "이전",
+  doneBtnText: "완료",
+  popoverClass: "boini-tour",
+  allowClose: true,
+  // AI 리포트 등에서 다음 스텝으로 넘어갈 때 대상 섹션까지 부드럽게 스크롤.
+  smoothScroll: true,
+  // 방향키를 투어 네비게이션에서 떼어낸다 — 발표 화면의 슬라이드 이동(←→)과 충돌 방지.
+  // (닫기는 X 버튼/오버레이 클릭으로 가능; ESC 는 함께 비활성화됨.)
+  allowKeyboardControl: false,
+  overlayColor: "#000",
+  stagePadding: 6,
+  stageRadius: 8,
+};
+
+const PRESET_CONFIG: Record<TourPreset, Partial<Config>> = {
+  default: { overlayOpacity: 0.6 },
+  // 라이브 중 방해 최소화: 화면을 거의 어둡게 하지 않고 스포트라이트만.
+  quiet: { overlayOpacity: 0.15, popoverClass: "boini-tour boini-tour--quiet" },
+};
+
+export function baseTourConfig(preset: TourPreset): Config {
+  return { ...BASE_CONFIG, ...PRESET_CONFIG[preset] };
+}
+
+export function toDriveSteps(steps: TourStepContent[]): DriveStep[] {
+  return steps.map((step) => ({
+    element: step.target,
+    popover: {
+      title: step.title,
+      description: step.body,
+      side: step.side,
+      align: step.align,
+    },
+  }));
+}
+
+export interface TourDriverHandlers {
+  onStep: (index: number) => void;
+  onEnd: (completed: boolean, index: number | undefined) => void;
+  onClosed: () => void;
+}
+
+export function createTourDriver(
+  preset: TourPreset,
+  steps: DriveStep[],
+  handlers: TourDriverHandlers
+): Driver {
+  const driverObj: Driver = driver({
+    ...baseTourConfig(preset),
+    steps,
+    onHighlightStarted: (_element, _step, opts) => {
+      handlers.onStep(opts.state.activeIndex ?? 0);
+    },
+    // X/ESC/오버레이 클릭/마지막 완료 모두 여기로 온다. 마지막 스텝이면 완료로 간주.
+    onDestroyStarted: () => {
+      const completed = !driverObj.hasNextStep();
+      handlers.onEnd(completed, driverObj.getActiveIndex());
+      driverObj.destroy();
+    },
+    onDestroyed: () => {
+      handlers.onClosed();
+    },
+  });
+  return driverObj;
+}

--- a/src/shared/lib/tour/index.ts
+++ b/src/shared/lib/tour/index.ts
@@ -1,0 +1,4 @@
+export type { TourSurface, TourPreset, TourStepContent } from "./types";
+export { tourReplayRequestAtom } from "./tour-atoms";
+export { tourSeen } from "./tour-seen";
+export { useTour } from "./useTour";

--- a/src/shared/lib/tour/tour-atoms.ts
+++ b/src/shared/lib/tour/tour-atoms.ts
@@ -1,0 +1,5 @@
+import { atom } from "jotai";
+import type { TourSurface } from "./types";
+
+/** 헤더 "가이드" 버튼이 현재 서페이스 투어 재생을 요청할 때 이 값을 세팅한다. */
+export const tourReplayRequestAtom = atom<TourSurface | null>(null);

--- a/src/shared/lib/tour/tour-seen.ts
+++ b/src/shared/lib/tour/tour-seen.ts
@@ -1,0 +1,27 @@
+import { storageKeys } from "@/shared/config/storage-keys";
+import type { TourSurface } from "./types";
+
+/** localStorage 기반 "이 서페이스 투어를 봤는지" 플래그. 첫 방문 자동 실행 판정에 사용. */
+export const tourSeen = {
+  isSeen(surface: TourSurface): boolean {
+    try {
+      return localStorage.getItem(storageKeys.tourSeen(surface)) === "true";
+    } catch {
+      return false;
+    }
+  },
+  markSeen(surface: TourSurface) {
+    try {
+      localStorage.setItem(storageKeys.tourSeen(surface), "true");
+    } catch {
+      /* ignore */
+    }
+  },
+  reset(surface: TourSurface) {
+    try {
+      localStorage.removeItem(storageKeys.tourSeen(surface));
+    } catch {
+      /* ignore */
+    }
+  },
+} as const;

--- a/src/shared/lib/tour/types.ts
+++ b/src/shared/lib/tour/types.ts
@@ -1,0 +1,12 @@
+export type TourSurface = "prepare" | "present" | "report";
+
+export type TourPreset = "default" | "quiet";
+
+/** Page-authored step content. `target` is a CSS selector; omit it for a centered modal step. */
+export interface TourStepContent {
+  target?: string;
+  title: string;
+  body: string;
+  side?: "top" | "right" | "bottom" | "left";
+  align?: "start" | "center" | "end";
+}

--- a/src/shared/lib/tour/useTour.ts
+++ b/src/shared/lib/tour/useTour.ts
@@ -1,0 +1,121 @@
+import { useCallback, useEffect, useRef } from "react";
+import { useAtom } from "jotai";
+import { usePostHog } from "@posthog/react";
+import type { Driver } from "driver.js";
+import { ANALYTICS_EVENTS, ANALYTICS_GROUP_SESSION } from "@/shared/config/analytics-events";
+import { createTourDriver, toDriveSteps } from "./driver-config";
+import { tourReplayRequestAtom } from "./tour-atoms";
+import { tourSeen } from "./tour-seen";
+import type { TourPreset, TourStepContent, TourSurface } from "./types";
+
+const MIN_DESKTOP_WIDTH = 1024;
+const AUTO_START_DELAY_MS = 400;
+
+// 투어 대상이 접힌 CollapsibleSection 안에 있을 수 있다(수동 재생 시). 시작 직전에
+// data-tour-expand 로 표시된 "접힌" 섹션 헤더만 눌러 펼친다. 이미 펼쳐져 있으면
+// (aria-expanded="true") 선택되지 않으므로 자동 실행 경로에서는 no-op 이다.
+function expandCollapsedTourSections() {
+  if (typeof document === "undefined") return;
+  document
+    .querySelectorAll<HTMLElement>('[data-tour-expand][aria-expanded="false"]')
+    .forEach((header) => header.click());
+}
+
+interface UseTourOptions {
+  surface: TourSurface;
+  steps: TourStepContent[];
+  /** Readiness gate — the tour only auto-starts once this is true and anchors exist. */
+  enabled: boolean;
+  preset?: TourPreset;
+  roomId?: string | null;
+}
+
+export function useTour({ surface, steps, enabled, preset = "default", roomId }: UseTourOptions): {
+  startTour: () => void;
+} {
+  const posthog = usePostHog();
+  const [replayRequest, setReplayRequest] = useAtom(tourReplayRequestAtom);
+  const driverRef = useRef<Driver | null>(null);
+  const autoStartedRef = useRef(false);
+  // 최신 steps/roomId 를 콜백에서 안정적으로 참조 (start 재생성 없이).
+  const stepsRef = useRef(steps);
+  const roomIdRef = useRef(roomId);
+  stepsRef.current = steps;
+  roomIdRef.current = roomId;
+
+  const start = useCallback(
+    (trigger: "auto" | "manual") => {
+      if (driverRef.current) return;
+      const currentSteps = stepsRef.current;
+      if (!currentSteps.length) return;
+
+      const currentRoomId = roomIdRef.current;
+      posthog?.capture(ANALYTICS_EVENTS.ONBOARDING_TOUR_STARTED, { surface, trigger });
+      if (currentRoomId) posthog?.group(ANALYTICS_GROUP_SESSION, currentRoomId);
+
+      const driverObj = createTourDriver(preset, toDriveSteps(currentSteps), {
+        onStep: (index) => {
+          posthog?.capture(ANALYTICS_EVENTS.ONBOARDING_TOUR_STEP_VIEWED, {
+            surface,
+            step_index: index,
+          });
+        },
+        onEnd: (completed, index) => {
+          posthog?.capture(
+            completed
+              ? ANALYTICS_EVENTS.ONBOARDING_TOUR_COMPLETED
+              : ANALYTICS_EVENTS.ONBOARDING_TOUR_SKIPPED,
+            { surface, step_index: index }
+          );
+          tourSeen.markSeen(surface);
+        },
+        onClosed: () => {
+          driverRef.current = null;
+        },
+      });
+
+      // 접힌 "세션 설정" 섹션 안의 앵커(prepare 스텝 5~9)가 숨어 있으면 시작 직전에 펼친다.
+      // .click() 은 discrete 이벤트라 collapsed 상태가 동기 flush 된다. 펼침 CSS 전환(~0.28s)은
+      // 사용자가 스텝 1→5 를 직접 넘겨오는 시간(사람이 4번 클릭)보다 훨씬 짧아, 그 앵커에 도달할 땐
+      // 항상 최종 레이아웃이다(인포메이션 투어라 자동 진행 없음). 자동 실행/다른 서페이스에선 no-op.
+      expandCollapsedTourSections();
+
+      driverRef.current = driverObj;
+      driverObj.drive();
+    },
+    [posthog, preset, surface]
+  );
+
+  // 첫 방문 자동 실행 — 데스크톱 & 미열람 & 준비 완료일 때 한 번만.
+  // ⚠️ StrictMode 이중 마운트 대비: ref 는 타이머가 "실제로 실행될 때" 세팅한다.
+  //    스케줄 전에 세팅하면, cleanup 이 타이머를 취소한 뒤 재마운트에서 ref 가드에 막혀
+  //    자동 실행이 영영 일어나지 않는다.
+  useEffect(() => {
+    if (autoStartedRef.current || !enabled) return;
+    if (tourSeen.isSeen(surface)) return;
+    if (typeof window !== "undefined" && window.innerWidth < MIN_DESKTOP_WIDTH) return;
+    const timer = setTimeout(() => {
+      autoStartedRef.current = true;
+      start("auto");
+    }, AUTO_START_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [enabled, surface, start]);
+
+  // 헤더 "가이드" 버튼 재생 요청 — 우리 서페이스면 시작하고 요청 플래그를 비운다.
+  useEffect(() => {
+    if (replayRequest !== surface) return;
+    setReplayRequest(null);
+    start("manual");
+  }, [replayRequest, surface, setReplayRequest, start]);
+
+  // 언마운트 시 열려 있던 투어 정리 (네비게이션 이탈 대비).
+  useEffect(
+    () => () => {
+      driverRef.current?.destroy();
+      driverRef.current = null;
+    },
+    []
+  );
+
+  return { startTour: useCallback(() => start("manual"), [start]) };
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -70,3 +70,51 @@ body {
     animation: boini-vt-in 0.35s cubic-bezier(0.16, 1, 0.3, 1) both;
   }
 }
+
+/* ── Onboarding tour (driver.js) theme ── */
+.driver-popover.boini-tour {
+  border-radius: 14px;
+  padding: 20px 22px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.16);
+  max-width: 320px;
+}
+.driver-popover.boini-tour .driver-popover-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: #303030;
+  line-height: 1.4;
+}
+.driver-popover.boini-tour .driver-popover-description {
+  font-size: 14px;
+  color: #5c5c5c;
+  line-height: 1.6;
+  margin-top: 6px;
+  /* 스텝 body 의 \n 을 실제 줄바꿈으로 렌더 (일반 줄바꿈/래핑은 그대로) */
+  white-space: pre-line;
+}
+.driver-popover.boini-tour .driver-popover-progress-text {
+  font-size: 12px;
+  color: #9e9e9e;
+}
+.driver-popover.boini-tour .driver-popover-navigation-btns button {
+  background: #fff;
+  color: #5c5c5c;
+  border: 1px solid #e6e6e6;
+  border-radius: 8px;
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  text-shadow: none;
+}
+.driver-popover.boini-tour .driver-popover-navigation-btns button.driver-popover-next-btn {
+  background: #e8541e;
+  border-color: #e8541e;
+  color: #fff;
+}
+.driver-popover.boini-tour .driver-popover-close-btn {
+  color: #9e9e9e;
+}
+/* quiet preset — 라이브 중 더 작고 덜 튀게 */
+.driver-popover.boini-tour--quiet {
+  max-width: 280px;
+}

--- a/src/widgets/app-header/ui/header/AppHeader.tsx
+++ b/src/widgets/app-header/ui/header/AppHeader.tsx
@@ -3,7 +3,7 @@ import styled, { css } from "styled-components";
 import { useLocation, useNavigate } from "react-router";
 import { usePostHog } from "@posthog/react";
 import { ANALYTICS_EVENTS } from "@/shared/config/analytics-events";
-import { useAtomValue } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 import BoiniLogo from "@/shared/assets/images/Boini_logo.svg";
 import LiveIcon from "@/shared/assets/images/live.png";
 import SessionQuestionFace from "@/shared/assets/images/session-question-face.svg";
@@ -14,6 +14,7 @@ import {
   StartSessionButton,
   FeedbackQuestionButton,
   CsvDownloadButton,
+  TourHelpButton,
 } from "./HeaderButtons";
 import { FeedbackQuestionModal } from "@/features/feedback-questions";
 import { leaveRoom } from "@/shared/api/room";
@@ -23,6 +24,8 @@ import {
   presenterModeAtom,
   audienceVoiceCsvEnabledAtom,
 } from "@/entities/room";
+import { tourReplayRequestAtom } from "@/shared/lib/tour";
+import type { TourSurface } from "@/shared/lib/tour";
 import { SessionLoadingOverlay } from "@/shared/ui/session-loading-overlay";
 import { SessionWarningModal } from "@/shared/ui/session-warning-modal";
 import {
@@ -128,6 +131,15 @@ function AppHeader({ roomData: propRoomData, totalPages }: AppHeaderProps) {
   const isPresenterRoom = /^\/rooms\/[^/]+$/.test(location.pathname);
   const isPrep = isPresenterRoom && presenterMode === "prepare";
   const isPresenter = isPresenterRoom && presenterMode === "present";
+
+  const setTourReplay = useSetAtom(tourReplayRequestAtom);
+  const tourSurface: TourSurface | null = isPrep
+    ? "prepare"
+    : isPresenter
+      ? "present"
+      : isAiReport
+        ? "report"
+        : null;
 
   const [showShareModal, setShowShareModal] = useState(false);
   const [showFeedbackQuestionModal, setShowFeedbackQuestionModal] = useState(false);
@@ -318,12 +330,27 @@ function AppHeader({ roomData: propRoomData, totalPages }: AppHeaderProps) {
 
         {(isAudienceView || isPrep || isPresenter || isAiReport) && (
           <RightActions>
-            {isPrep && <FeedbackQuestionButton onClick={handleFeedbackQuestionClick} />}
+            {tourSurface && (
+              <TourHelpButton
+                onClick={() => setTourReplay(tourSurface)}
+                aria-label="온보딩 가이드 다시 보기"
+              />
+            )}
 
-            {(isPrep || isPresenter) && <ShareButton onClick={handleShareClick} />}
+            {isPrep && (
+              <FeedbackQuestionButton
+                data-tour="feedback-form-button"
+                onClick={handleFeedbackQuestionClick}
+              />
+            )}
+
+            {(isPrep || isPresenter) && (
+              <ShareButton data-tour="share-button" onClick={handleShareClick} />
+            )}
 
             {(isPrep || isPresenter) && (
               <StartSessionButton
+                data-tour="start-session-button"
                 onClick={handleStartSessionClick}
                 disabled={isSessionEnding || (isPrep && !resolvedCanStartSession)}
                 isEndSession={isPresenter}
@@ -334,12 +361,15 @@ function AppHeader({ roomData: propRoomData, totalPages }: AppHeaderProps) {
 
             {isAiReport && (
               <CsvDownloadButton
+                data-tour="csv-download-button"
                 onClick={handleDownloadCsv}
                 disabled={csvDownloading || !csvEnabled}
               />
             )}
 
-            {(isAudienceView || isAiReport) && <ExitButton onClick={handleExitClick} />}
+            {(isAudienceView || isAiReport) && (
+              <ExitButton data-tour="exit-button" onClick={handleExitClick} />
+            )}
           </RightActions>
         )}
       </HeaderWrapper>

--- a/src/widgets/app-header/ui/header/HeaderButtons.tsx
+++ b/src/widgets/app-header/ui/header/HeaderButtons.tsx
@@ -5,6 +5,7 @@ import PlayIconDefault from "@/shared/assets/images/play2.svg";
 import ExitIconDefault from "@/shared/assets/images/getout.png";
 import FilesIconDefault from "@/shared/assets/images/files.svg";
 import DownloadCsvIconDefault from "@/shared/assets/images/AI/download-csv.svg";
+import HelpIconDefault from "@/shared/assets/images/help.svg";
 
 const BasePillButton = styled.button`
   display: inline-flex;
@@ -192,6 +193,18 @@ export const ExitButton = ({
   <ExitPillButton ref={ref} {...props}>
     {renderContent(iconSrc, iconAlt, children)}
   </ExitPillButton>
+);
+
+export const TourHelpButton = ({
+  children = "퀵 가이드",
+  iconSrc = HelpIconDefault,
+  iconAlt = typeof children === "string" ? children : "퀵 가이드",
+  ref,
+  ...props
+}: ButtonProps) => (
+  <BasePillButton ref={ref} {...props}>
+    {renderContent(iconSrc, iconAlt, children)}
+  </BasePillButton>
 );
 
 export { BasePillButton };

--- a/src/widgets/presentation-layout/ui/settings/BroadcastScreenControl.tsx
+++ b/src/widgets/presentation-layout/ui/settings/BroadcastScreenControl.tsx
@@ -45,7 +45,7 @@ const BroadcastScreenControl = ({
     : "새 창에서 오직 슬라이드 화면만이 보여집니다.";
 
   return (
-    <ControlWrapper>
+    <ControlWrapper data-tour="setting-broadcast">
       <ControlBox>
         <ControlText>
           <ControlLabel>깔끔한 발표 화면</ControlLabel>

--- a/src/widgets/presentation-layout/ui/settings/PdfDownloadPolicyControl.tsx
+++ b/src/widgets/presentation-layout/ui/settings/PdfDownloadPolicyControl.tsx
@@ -21,7 +21,7 @@ const PdfDownloadPolicyControl = ({
   error = null,
   onChange,
 }: PdfDownloadPolicyControlProps) => (
-  <PolicyWrapper>
+  <PolicyWrapper data-tour="setting-pdf">
     <PolicyBox>
       <PolicyText>
         <PolicyLabel>슬라이드 다운로드 허용</PolicyLabel>

--- a/src/widgets/presentation-layout/ui/settings/SettingsPanel.tsx
+++ b/src/widgets/presentation-layout/ui/settings/SettingsPanel.tsx
@@ -60,12 +60,17 @@ interface QuickSettingToggleProps {
   checked: boolean;
   onChange: ChangeEventHandler<HTMLInputElement>;
   disabled?: boolean;
+  dataTour?: string;
 }
 
 interface CollapsibleSectionProps {
   title: string;
   defaultCollapsed?: boolean;
   children: React.ReactNode;
+  // 온보딩 투어가 시작 전 자동으로 펼칠 수 있도록 헤더에 data-tour-expand 를 단다.
+  expandableForTour?: boolean;
+  // 온보딩 투어 앵커 — 섹션 전체를 하이라이트할 때 사용.
+  dataTour?: string;
 }
 
 const SettingsPanel = ({
@@ -93,15 +98,18 @@ const CollapsibleSection = ({
   title,
   defaultCollapsed = false,
   children,
+  expandableForTour = false,
+  dataTour,
 }: CollapsibleSectionProps) => {
   const [collapsed, setCollapsed] = useState(defaultCollapsed);
 
   return (
-    <Section>
+    <Section data-tour={dataTour}>
       <SectionHeader
         type="button"
         onClick={() => setCollapsed((prev) => !prev)}
         aria-expanded={!collapsed}
+        data-tour-expand={expandableForTour ? "" : undefined}
       >
         {title}
         <SectionChevron src={ChevronIcon} alt="" aria-hidden="true" $collapsed={collapsed} />
@@ -153,25 +161,28 @@ const SessionSettingsSection = ({
   SettingsPanelProps,
   "quickSettings" | "onOptionChange" | "onUnlockChange" | "prepSettingsContent"
 >) => (
-  <CollapsibleSection title="세션 설정">
+  <CollapsibleSection title="세션 설정" expandableForTour>
     <QuickTogglesGrid>
       <QuickSettingToggle
         label="실시간 질문"
         description="청중이 실시간으로 질문을 남길 수 있습니다."
         checked={quickSettings.question}
         onChange={(event) => onOptionChange?.("question", event.target.checked)}
+        dataTour="setting-question"
       />
       <QuickSettingToggle
         label="리액션 스티커"
         description="청중이 리액션 스티커로 반응을 남길 수 있습니다."
         checked={quickSettings.sticker}
         onChange={(event) => onOptionChange?.("sticker", event.target.checked)}
+        dataTour="setting-sticker"
       />
       <QuickSettingToggle
         label="다음 구간 슬라이드 공개하기"
         description="청중이 다음 슬라이드 화면들을 미리 볼 수 있습니다."
         checked={quickSettings.unlock}
         onChange={(event) => onUnlockChange?.(event.target.checked)}
+        dataTour="setting-unlock"
       />
       {prepSettingsContent}
     </QuickTogglesGrid>
@@ -280,8 +291,9 @@ const QuickSettingToggle = ({
   checked,
   onChange,
   disabled = false,
+  dataTour,
 }: QuickSettingToggleProps) => (
-  <ToggleBox>
+  <ToggleBox data-tour={dataTour}>
     <ToggleText>
       <ToggleLabel>{label}</ToggleLabel>
       <ToggleDescription>{description}</ToggleDescription>
@@ -301,7 +313,7 @@ const LiveQuestionSection = ({
 }: {
   quickSettings?: QuickSettings;
 }) => (
-  <FillSection>
+  <FillSection data-tour="live-question-panel">
     <Title>실시간 질문</Title>
     <LiveWaitingBox isQuestionEnabled={quickSettings.question} />
   </FillSection>

--- a/src/widgets/presentation-layout/ui/viewer/SlideContainer.tsx
+++ b/src/widgets/presentation-layout/ui/viewer/SlideContainer.tsx
@@ -22,6 +22,7 @@ const SlideContainer = ({
   showStamps = true,
   highlight = false,
   testId,
+  dataTour,
 }: any) => {
   const imageBorderColor = highlight ? "#ffc551" : "#eee";
 
@@ -46,7 +47,7 @@ const SlideContainer = ({
   };
 
   return (
-    <SlideBox ref={boxRef} highlight={highlight} data-testid={testId}>
+    <SlideBox ref={boxRef} highlight={highlight} data-testid={testId} data-tour={dataTour}>
       {hasSrc ? (
         <img
           key={src}

--- a/src/widgets/presentation-layout/ui/viewer/SlideViewer.tsx
+++ b/src/widgets/presentation-layout/ui/viewer/SlideViewer.tsx
@@ -83,7 +83,7 @@ const SlideViewer = ({
       <FocusBar>
         {/* 🔹 왼쪽 그룹 (집중유도 + 검정바) */}
         <FocusGroupLeft>
-          <FocusLeft onClick={onFocusClick}>
+          <FocusLeft onClick={onFocusClick} data-tour="focus-button">
             <img src={FocusIcon} alt="집중 유도" width={20} height={20} />
             <span>집중 유도</span>
           </FocusLeft>
@@ -142,7 +142,7 @@ const SlideViewer = ({
           )}
           <TooltipHoverArea>
             <Tooltip>리액션 스티커 보이기</Tooltip>
-            <ReactionButton onClick={handleToggleEyesClick}>
+            <ReactionButton onClick={handleToggleEyesClick} data-tour="sticker-visibility">
               <img
                 src={showReactions ? openeyes : closeeyes}
                 alt={showReactions ? "openeyes" : "closeeyes"}
@@ -164,6 +164,7 @@ const SlideViewer = ({
         showStamps={showReactions}
         highlight={focusHighlight}
         testId="presenter-slide-surface"
+        dataTour="slide-surface"
       />
 
       {afterSlideContent}


### PR DESCRIPTION
## 🚀 배포 개요

`dev` → `main` 병합 배포입니다. 병합 시 Cloudflare Pages가 프로덕션에 자동 반영합니다.

## 📦 주요 변경사항

**✨ 기능**
- **발표자 온보딩 투어 추가** — 처음 사용하는 발표자에게 준비 → 라이브 발표 → AI 리포트까지 각 화면에서 무엇을 하고 다음에 무엇을 할지 안내합니다.
  - 준비 화면: 콘솔 전체 안내(슬라이드·집중 유도·세션 설정·질문 패널·공유·시작)
  - 라이브 발표: 방해를 줄인 간결 3스텝(화면 → 세션 설정 → 종료), 설정은 발표 중 변경 가능 안내
  - AI 리포트: 섹션별 스크롤 안내 + CSV 다운로드 + 나가기
  - 화면별 첫 방문 시 1회 자동 실행(브라우저 localStorage 기준), 헤더 **"가이드"** 버튼으로 언제든 재생

## ⚠️ 환경 변수 / 배포 설정 변경

- 환경 변수 변경 없음

## 📝 추가 참고사항

- 신규 런타임 의존성 `driver.js@^1.8.0` 추가(온보딩 투어 엔진, 약 5KB) — Cloudflare Pages 빌드 시 자동 설치됨
- 백엔드 변경 없음 · 신규 유닛 테스트 없음(프로젝트 컨벤션, `pnpm typecheck`/`pnpm build` 통과)